### PR TITLE
Add Comment model and migration

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,6 @@
+class Comment < ApplicationRecord
+  belongs_to :user
+  belongs_to :smoking_area
+
+  validates :content, presence: true, length: {maximum: 500}
+end

--- a/db/migrate/20250729131023_create_comments.rb
+++ b/db/migrate/20250729131023_create_comments.rb
@@ -1,0 +1,11 @@
+class CreateComments < ActiveRecord::Migration[7.1]
+  def change
+    create_table :comments do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :smoking_area, null: false, foreign_key: true
+      t.text :content, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_07_27_020702) do
+ActiveRecord::Schema[7.1].define(version: 2025_07_29_131023) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -40,6 +40,16 @@ ActiveRecord::Schema[7.1].define(version: 2025_07_27_020702) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "comments", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "smoking_area_id", null: false
+    t.text "content", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["smoking_area_id"], name: "index_comments_on_smoking_area_id"
+    t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
   create_table "photos", force: :cascade do |t|
@@ -121,6 +131,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_07_27_020702) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "comments", "smoking_areas"
+  add_foreign_key "comments", "users"
   add_foreign_key "photos", "smoking_areas"
   add_foreign_key "reports", "report_statuses"
   add_foreign_key "reports", "users"

--- a/test/fixtures/comments.yml
+++ b/test/fixtures/comments.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  smoking_area: one
+  content: MyText
+
+two:
+  user: two
+  smoking_area: two
+  content: MyText

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CommentTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
commentsテーブルのマイグレーションとモデルを作成した

## 内容
 - Commentモデルの作成(user、smoking_areaとの関連付け)
 - Commentモデルに `belongs_to :user` と `belongs_to :smoking_area` を追加(自動生成)
 - contentカラムにpresenceと最大文字数500文字のバリデーションを追加
 - マイグレーションファイルに外部キー制約とnull制約を追加

## 関連Issue
Closes #1
