### PR TITLE
Add has_many :comments association to User and SmokingArea

### DIFF
--- a/app/models/smoking_area.rb
+++ b/app/models/smoking_area.rb
@@ -4,6 +4,7 @@ class SmokingArea < ApplicationRecord
   belongs_to :smoking_area_type
 
   has_many :photos
+  has_many :comments
 
   validates :name, presence: true, length: {maximum: 50}
   validates :latitude, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@ class User < ApplicationRecord
     has_secure_password
 
     has_many :smoking_areas
+    has_many :comments
 
     validates :name, presence: true, length: {maximum: 50}
     validates :email, presence: true, uniqueness: true, format: { with: URI::MailTo::EMAIL_REGEXP }


### PR DESCRIPTION
## 概要
UserモデルとSmokingAreaモデルにcommentsテーブルとのアソシエーションを追加

## 内容
- user.rbに has_many :comments を追加
- smoking_area.rbに has_many :comments を追加

## 動作確認
- rails consoleで user.comments と area.comments を取得できる
- comment.save => true が成功する
- rails s が起動する

## 関連Issue
Closes #3