### PR TITLE
tobacco_typesテーブルにiconカラムを追加して、seedでの重複防止対応を実施

### DIFF
--- a/db/migrate/20250801123425_add_icon_to_tobacco_types.rb
+++ b/db/migrate/20250801123425_add_icon_to_tobacco_types.rb
@@ -1,0 +1,5 @@
+class AddIconToTobaccoTypes < ActiveRecord::Migration[7.1]
+  def change
+    add_column :tobacco_types, :icon, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_07_29_131023) do
+ActiveRecord::Schema[7.1].define(version: 2025_08_01_123425) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -118,6 +118,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_07_29_131023) do
     t.string "kinds"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "icon"
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -21,7 +21,7 @@ SmokingAreaType.create!([
     {name: "公共", icon: "public", color: "#1976D2"},
     {name: "施設内", icon: "mall", color: "#43A047"},
     {name: "飲食店", icon: "restaurant", color: "#8D6E63"},
-    {name: "カフェ", icon: "cafe", color: "#795548"}
+    {name: "カフェ", icon: "cafe", color: "#795548"},
     {name: "コンビニ", icon: "convenience", color: "#FB8C00"},
     {name: "その他", icon: "other", color: "#9E9E9E"}
 ])

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,10 @@
-TobaccoType.create!([
-    {kinds: "紙タバコ"},
-    {kinds: "電子タバコ"}
-])
+TobaccoType.find_or_create_by!(kinds: "紙タバコ") do |t|
+    t.icon = "🚬"
+end
+
+TobaccoType.find_or_create_by!(kinds: "電子タバコ") do |t|
+    t.icon = "電子"
+end
 
 SmokingAreaStatus.create!([
     {name: "公開中"},


### PR DESCRIPTION
## 概要
- tobacco_typesテーブルに、UI表示用のiconカラムを追加
- 初期データ投入時の重複防止のため、seeds.rbでの記述をcreate!からfind_or_create_by!に変更
- seeds.rbでの `,`の記述漏れを修正

## 背景
- 喫煙所を地図表示する機能がメイン機能のため、それに付随したフィルター機能をUI表示させるためiconの情報が必要となりiconカラムを追加

## 内容
- iconカラムのマイグレーションを追加
- seed.rbのTobaccoTypeの内容の登録と記述をcreate!からfind_or_create_by!に変更
- seed.rbのSmokingAreaTypeでの `,`の記述漏れを修正

## 動作確認
- rails db:migrateを実行してエラーが出ないことを確認
- rails db:seedを実行してエラーが出ないことを確認
- rails cでTobaccoType.allを実行して、iconが含まれかつ登録した内容が出力されること

## 関連Issue
Closes#5