### PR TITLE
update seeds.rb to prevent duplicate records on multiple executions

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,22 +6,30 @@ TobaccoType.find_or_create_by!(kinds: "電子タバコ") do |t|
     t.icon = "電子"
 end
 
-SmokingAreaStatus.create!([
-    {name: "公開中"},
-    {name: "公開停止中"}
-])
+SmokingAreaStatus.find_or_create_by!(name: "公開中")
 
-ReportStatus.create!([
-    {name: "対応前"},
-    {name: "対応済み"},
-    {name: "対応中"}
-])
+SmokingAreaStatus.find_or_create_by!(name: "公開停止中")
 
-SmokingAreaType.create!([
+
+ReportStatus.find_or_create_by!(name: "対応前")
+
+ReportStatus.find_or_create_by!(name: "対応済み")
+
+ReportStatus.find_or_create_by!(name: "対応中")
+
+
+SmokingAreaTypeData = [
     {name: "公共", icon: "public", color: "#1976D2"},
     {name: "施設内", icon: "mall", color: "#43A047"},
     {name: "飲食店", icon: "restaurant", color: "#8D6E63"},
     {name: "カフェ", icon: "cafe", color: "#795548"},
     {name: "コンビニ", icon: "convenience", color: "#FB8C00"},
     {name: "その他", icon: "other", color: "#9E9E9E"}
-])
+]
+
+SmokingAreaTypeData.each do |data|
+    type = SmokingAreaType.find_or_initialize_by(name: data[:name])
+    type.icon = data[:icon]
+    type.color = data[:color]
+    type.save!
+end


### PR DESCRIPTION
## 概要
`db:seed` を複数回実行した際に、重複レコードが発生しないように `seeds.rb` の記述内容を変更

## 背景
- `db:seed` を複数回実行しても、重複レコードの発生を防止するため
- 状態の一貫性を保ち、開発及び本番環境で安全に初期データを投入できるようにするため

## 内容
- `SmokingAreaStatus` を `create!` から `find_or_create_by!(name: ...)` に記述内容を変更
- `ReportStatus` を ` create!` から `find_or_create_by!(name: ...)` に記述内容を変更
- `SmokingAreaType` を `create!` から `find_or_initialize_by` に変更し、`icon` と `color` を毎回上書きしてから `save!` する処理に変更

## 動作確認
- `rails db:seed` 実行時にエラーが出ないことを確認
- `rails c` で以下の出力を確認
  - `SmokingAreaStatus.all` で各ステータスの `name` が確認できること
  - `ReportStatus.all` で各ステータスの `name` が確認できること
  - `SmokingAreaType.all` で `name`, `icon`, `color` が確認できること

## 関連Issue
Closes #7 