### PR TITLE
feat: Add a model and migration for the smoking_area_tobacco_types table

### DIFF
--- a/app/models/smoking_area_tobacco_type.rb
+++ b/app/models/smoking_area_tobacco_type.rb
@@ -1,0 +1,7 @@
+class SmokingAreaTobaccoType < ApplicationRecord
+  belongs_to :smoking_area
+  belongs_to :tobacco_type
+
+  validates :smoking_area_id, presence: true
+  validates :tobacco_type_id, presence: true
+end

--- a/db/migrate/20250806094641_create_smoking_area_tobacco_types.rb
+++ b/db/migrate/20250806094641_create_smoking_area_tobacco_types.rb
@@ -1,0 +1,12 @@
+class CreateSmokingAreaTobaccoTypes < ActiveRecord::Migration[7.1]
+  def change
+    create_table :smoking_area_tobacco_types do |t|
+      t.references :smoking_area, null: false, foreign_key: true
+      t.references :tobacco_type, null: false, foreign_key: true
+
+      t.index [:smoking_area_id, :tobacco_type_id], unique: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_08_01_123425) do
+ActiveRecord::Schema[7.1].define(version: 2025_08_06_094641) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -85,6 +85,16 @@ ActiveRecord::Schema[7.1].define(version: 2025_08_01_123425) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "smoking_area_tobacco_types", force: :cascade do |t|
+    t.bigint "smoking_area_id", null: false
+    t.bigint "tobacco_type_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["smoking_area_id", "tobacco_type_id"], name: "idx_on_smoking_area_id_tobacco_type_id_bc76b2e19e", unique: true
+    t.index ["smoking_area_id"], name: "index_smoking_area_tobacco_types_on_smoking_area_id"
+    t.index ["tobacco_type_id"], name: "index_smoking_area_tobacco_types_on_tobacco_type_id"
+  end
+
   create_table "smoking_area_types", force: :cascade do |t|
     t.string "name"
     t.string "icon"
@@ -137,6 +147,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_08_01_123425) do
   add_foreign_key "photos", "smoking_areas"
   add_foreign_key "reports", "report_statuses"
   add_foreign_key "reports", "users"
+  add_foreign_key "smoking_area_tobacco_types", "smoking_areas"
+  add_foreign_key "smoking_area_tobacco_types", "tobacco_types"
   add_foreign_key "smoking_areas", "smoking_area_statuses"
   add_foreign_key "smoking_areas", "smoking_area_types"
   add_foreign_key "smoking_areas", "users"


### PR DESCRIPTION
## 概要
`smoking_area_tobacco_types` 中間テーブルを作成し、喫煙所とタバコ種別の多対多関係を構築

## 背景
喫煙所が複数のタバコ種別に対応しており、DB設計上中間テーブルが必要だったため

## 内容
- `SmokingAreaTobaccoType` のマイグレーションファイルの作成
- `SmokingAreaTobaccoType` のモデルファイルの作成
  - `belongs_to :smoking_area` と `belongs_to :tobacco_type` を記述
  -以下のバリデーションを追記 
    - `validates :smoking_area_id, presence: true` 
    - `validates :tobacco_type_id, presence: true`
- マイグレーションファイルに外部キー制約 `foreign_key: true` を `smoking_area_id` と `tobacco_type_id` に対して追加
- 複合インデックス `t.index [:smoking_area_id, :tobacco_type_id], unique: true` の追加
- `rails db:migrate` でマイグレーションを実行

## 動作確認
- `rails db:migrate` を実行してエラーがないことを確認
- `rails dbconsole` で `\d smoking_area_tobacco_types;` を実行し以下を確認
  - `id` , `smoking_area_id` , `tobacco_type_id` , `created_at` , `updated_at` の5つのカラムが存在すること
  - `smoking_area_id` と `tobacco_type_id` に外部キー制約が設定されている
  - `(smoking_area_id, tobacco_type_id)` の複合ユニークインデックスが存在する
- `rails db:rollback` を実行して、エラーなくロールバックできることを確認

## 関連Issue
Closes #9 