### PR TITLE
Feature/add has many through to smoking area and tobacco type

### DIFF
--- a/app/models/smoking_area.rb
+++ b/app/models/smoking_area.rb
@@ -5,6 +5,8 @@ class SmokingArea < ApplicationRecord
 
   has_many :photos
   has_many :comments
+  has_many :smoking_area_tobacco_types
+  has_many :tobacco_types, through: :smoking_area_tobacco_types
 
   validates :name, presence: true, length: {maximum: 50}
   validates :latitude, presence: true

--- a/app/models/tobacco_type.rb
+++ b/app/models/tobacco_type.rb
@@ -1,2 +1,4 @@
 class TobaccoType < ApplicationRecord
+    has_many :smoking_area_tobacco_types
+    has_many :smoking_areas, through: :smoking_area_tobacco_types
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,35 +1,52 @@
-TobaccoType.find_or_create_by!(kinds: "紙タバコ") do |t|
-    t.icon = "🚬"
-end
+t = TobaccoType.find_or_initialize_by(kinds: "紙タバコ")
+t.icon = "🚬"
+t.save!
 
-TobaccoType.find_or_create_by!(kinds: "電子タバコ") do |t|
-    t.icon = "電子"
-end
+t = TobaccoType.find_or_initialize_by(kinds: "電子タバコ")
+t.icon = "電子"
+t.save!
 
 SmokingAreaStatus.find_or_create_by!(name: "公開中")
-
 SmokingAreaStatus.find_or_create_by!(name: "公開停止中")
 
-
 ReportStatus.find_or_create_by!(name: "対応前")
-
 ReportStatus.find_or_create_by!(name: "対応済み")
-
 ReportStatus.find_or_create_by!(name: "対応中")
 
-
 SmokingAreaTypeData = [
-    {name: "公共", icon: "public", color: "#1976D2"},
-    {name: "施設内", icon: "mall", color: "#43A047"},
-    {name: "飲食店", icon: "restaurant", color: "#8D6E63"},
-    {name: "カフェ", icon: "cafe", color: "#795548"},
-    {name: "コンビニ", icon: "convenience", color: "#FB8C00"},
-    {name: "その他", icon: "other", color: "#9E9E9E"}
+  {name: "公共",   icon: "public",      color: "#1976D2"},
+  {name: "施設内", icon: "mall",        color: "#43A047"},
+  {name: "飲食店", icon: "restaurant",  color: "#8D6E63"},
+  {name: "カフェ", icon: "cafe",        color: "#795548"},
+  {name: "コンビニ", icon: "convenience", color: "#FB8C00"},
+  {name: "その他", icon: "other",       color: "#9E9E9E"}
 ]
-
 SmokingAreaTypeData.each do |data|
-    type = SmokingAreaType.find_or_initialize_by(name: data[:name])
-    type.icon = data[:icon]
-    type.color = data[:color]
-    type.save!
+  type = SmokingAreaType.find_or_initialize_by(name: data[:name])
+  type.icon  = data[:icon]
+  type.color = data[:color]
+  type.save!
 end
+
+#以下仮データ
+user = User.find_or_create_by!(email: "test@example.com") do |u|
+  u.password = "password"
+  u.name     = "テストユーザー"
+end
+
+status = SmokingAreaStatus.find_by!(name: "公開中")
+type   = SmokingAreaType.find_by!(name: "公共")
+
+paper  = TobaccoType.find_by!(kinds: "紙タバコ")
+ecig   = TobaccoType.find_by!(kinds: "電子タバコ")
+
+smk = SmokingArea.find_or_initialize_by(name: "新宿駅東口", address: "東京都新宿区新宿3丁目38")
+smk.assign_attributes(
+  user:                user,
+  smoking_area_status: status,
+  smoking_area_type:   type,
+  latitude:            35.6895,
+  longitude:           139.6917
+)
+smk.save!
+smk.tobacco_types = [paper, ecig]


### PR DESCRIPTION
## 概要
- `has_many :through` のアソシエーションで、「多対多」のリレーションシップを設定
- `has_many :through` のアソシエーションでの動作確認及び動作確認に必要なseedデータの記述

## 背景
- `smoking_areas` と `tobacco_types` テーブルの中間テーブル `smoking_area_tobacco_types` を経由する関連付けをするため
- `seeds.rb` で以下を実施
  - `has_many :through` のアソシエーションでの動作確認のための検証用仮データの記述
  - マスタ-データを改善

## 内容
### モデルファイル
- モデルファイル `smoking_area.rb` に以下を追記
  - `has_many :smoking_area_tobacco_types` を記述
  - `has_many :tobacco_types, through: :smoking_area_tobacco_types` を記述
- モデルファイル `tobacco_type.rb` に以下を追記
  - `has_many :smoking_area_tobacco_types` を記述
  - has_many :smoking_areas, through: :smoking_area_tobacco_types を記述
- `rails db:seed` を実行

### seeds.rb
 - 以下の検証用仮データを記述
   - 動作確認用の仮ユーザー、喫煙所データを追加
   - `has_many :through` の関連付け検証用に、喫煙所とタバコ種別の関連データを設定
 - 本番用マスターデータの記述を改善
   - `TobaccoType` の登録処理をを `find_or_initialize_by` に変更し、アイコンの更新も可能にした
   - `SmokingAreaType` 登録処理を `find_or_initialize_by` に変更し、アイコン・色の更新も可能にした


## 動作確認
- `rails db:seed` を実行してエラーが出ないことを確認
- `rails c` で以下の操作を確認
  - `SmokingArea.first!.tobacco_types` で関連データが取得できる
  - `ids = TobaccoType.where(kinds: ["紙巻きタバコ", "電子タバコ"]).ids`
     `SmokingArea.first.tobacco_type_ids = ids` でタバコ種別の紐づけができる
  - `SmokingArea.first!.tobacco_types.delete( TobaccoType.find_by!(kinds: "電子タバコ"))` により紐づけの解除ができる

 
## 関連Issue
Closes #11 