### PR TITLE
chore: enable bcrypt gem for password hashing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem "puma", ">= 5.0"
 # gem "kredis"
 
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
-# gem "bcrypt", "~> 3.1.7"
+gem "bcrypt", "~> 3.1.7"
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ windows jruby ]
@@ -44,4 +44,3 @@ group :development do
   # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
   # gem "spring"
 end
-

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,7 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0)
     base64 (0.3.0)
+    bcrypt (3.1.20)
     benchmark (0.4.1)
     bigdecimal (3.2.2)
     bootsnap (1.18.6)
@@ -220,6 +221,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  bcrypt (~> 3.1.7)
   bootsnap
   debug
   pg (~> 1.1)


### PR DESCRIPTION
## 概要
パスワードハッシュに `bcrypt` の依存関係を追加

## 背景
ユーザーのパスワードハッシュに `bcrypt` を使用するため

## 内容
- `Gemfile` にある `gem 'bcrypt', '~> 3.1.7'` の記述を有効化
- ターミナルで `bundle install` を実行
- `Gemfile.lock` を開き、`bcrypt (3.1.x)` の記載が追加されていることを確認
- 変更ファイル: `Gemfile`, `Gemfile.lock`（アプリコードの変更なし）

## 影響範囲
依存追加のみ。DB変更なし、既存機能への影響なし

## 動作確認
- `rails c` で `BCrypt::Password.create('test')` を実行しエラーが出ないことを確認
- `rails s` を実行し正常にサーバーが起動できることを確認

## 関連Issue
Closes #13 