### PR TITLE
feat(model): add minimal validations to Report and TobaccoType

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -2,4 +2,6 @@ class Report < ApplicationRecord
   belongs_to :user
   belongs_to :report_status
   belongs_to :targetable, polymorphic: true
+
+  validates :reason, presence: true
 end

--- a/app/models/tobacco_type.rb
+++ b/app/models/tobacco_type.rb
@@ -1,4 +1,7 @@
 class TobaccoType < ApplicationRecord
     has_many :smoking_area_tobacco_types
     has_many :smoking_areas, through: :smoking_area_tobacco_types
+
+    validates :kinds, presence: true, uniqueness: true
+    validates :icon, presence: true
 end


### PR DESCRIPTION
## 概要
`report.rb` , `tobacco_type.rb` に最小限のバリデーションの追加

## 背景
- Reporsテーブルの `reason` カラムの入力を必須にしたい
- TobaccoTypesテーブルの `kinds` , `icon` カラムを必須にしたい
- TobaccoTypesテーブルの `kinds` カラムは重複登録できないようにしたい

## 内容
- `report.rb` の `reason` カラムに `presence: true` を追加
- `tobacco_type.rb` の `kinds` , `icon` カラムに `presence: true` を追加
- `tobacco_type.rb` の `kinds` カラムに `uniqueness: true` を追加

## 備考
- 本PRは最小限のバリデーション追加に留めています
- DB制約（NOT NULL・ユニークインデックス）は別PRで追加予定