### PR TITLE
chore(db): add constraints and indexes to schema

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_08_06_094641) do
+ActiveRecord::Schema[7.1].define(version: 2025_08_15_110842) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -60,16 +60,16 @@ ActiveRecord::Schema[7.1].define(version: 2025_08_06_094641) do
   end
 
   create_table "report_statuses", force: :cascade do |t|
-    t.string "name"
+    t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_report_statuses_on_name", unique: true
   end
 
   create_table "reports", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "report_status_id", null: false
-    t.string "target_type"
-    t.text "reason"
+    t.text "reason", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "targetable_type", null: false
@@ -80,9 +80,10 @@ ActiveRecord::Schema[7.1].define(version: 2025_08_06_094641) do
   end
 
   create_table "smoking_area_statuses", force: :cascade do |t|
-    t.string "name"
+    t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_smoking_area_statuses_on_name", unique: true
   end
 
   create_table "smoking_area_tobacco_types", force: :cascade do |t|
@@ -96,11 +97,14 @@ ActiveRecord::Schema[7.1].define(version: 2025_08_06_094641) do
   end
 
   create_table "smoking_area_types", force: :cascade do |t|
-    t.string "name"
-    t.string "icon"
-    t.string "color"
+    t.string "name", null: false
+    t.string "icon", null: false
+    t.string "color", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "code", null: false
+    t.index ["code"], name: "index_smoking_area_types_on_code", unique: true
+    t.check_constraint "color::text ~ '^#[0-9A-Fa-f]{6}$'::text", name: "chk_smoking_area_types_color_hex"
   end
 
   create_table "smoking_areas", force: :cascade do |t|
@@ -125,10 +129,11 @@ ActiveRecord::Schema[7.1].define(version: 2025_08_06_094641) do
   end
 
   create_table "tobacco_types", force: :cascade do |t|
-    t.string "kinds"
+    t.string "kinds", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "icon"
+    t.string "icon", null: false
+    t.index ["kinds"], name: "index_tobacco_types_on_kinds", unique: true
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
## 概要
DBスキーマに制約・インデックスを追加

## 内容
- `report_statuses` テーブルの `name` カラムに `null: false` + `unique index` を追加
- `reports` テーブルの `reason` カラムに `null: false` を追加
- `smoking_area_statuses` テーブルの `name` カラムに `null: false` + `unique index` を追加
- `smoking_area_types` テーブルに以下を適用
  - `name` , `icon`, `color` カラムに `null: false` を追加
  - `code` カラムに `null: false` , `unique index` を追加
  - `color` カラムに HEX形式チェック制約（ `chk_smoking_area_types_color_hex` ）を追加
- `tobacco_types` テーブルに以下を適用
  - `kinds`, `icon` カラムに `null: false` を追加
  - `kinds` カラムに `unique index` を追加

## 備考
- モデル側のバリデーション追加とは別PRで管理
- seed整備は次のPRで対応予定

## 動作確認
- `rails db:migrate` を実行してエラーが出ないことを確認
- `db/schema.rb` に上記の制約・インデックスが反映されていること