### PR TITLE
chore(db): add missing migrations for schema constraints

### DIFF
--- a/db/migrate/20250813143131_fix_reports_columns.rb
+++ b/db/migrate/20250813143131_fix_reports_columns.rb
@@ -1,0 +1,12 @@
+class FixReportsColumns < ActiveRecord::Migration[7.1]
+  def up
+    execute "UPDATE reports SET reason = 'unspecified' WHERE reason IS NULL"
+    change_column_null :reports, :reason, false
+    remove_column :reports, :target_type, :string if column_exists?(:reports, :target_type)
+  end
+
+  def down
+    add_column :reports, :target_type, :string unless column_exists?(:reports, :target_type)
+    change_column_null :reports, :reason, true
+  end
+end

--- a/db/migrate/20250813161813_fix_statuses_name_not_null.rb
+++ b/db/migrate/20250813161813_fix_statuses_name_not_null.rb
@@ -1,0 +1,18 @@
+class FixStatusesNameNotNull < ActiveRecord::Migration[7.1]
+  def up
+    change_column_null :report_statuses, :name, false
+    change_column_null :smoking_area_statuses, :name, false
+
+    # unique index がなければ追加（重複登録を防ぐため）
+    add_index :report_statuses, :name, unique: true unless index_exists?(:report_statuses, :name, unique: true)
+    add_index :smoking_area_statuses, :name, unique: true unless index_exists?(:smoking_area_statuses, :name)
+  end
+
+  def down
+    remove_index :report_statuses, :name if index_exists?(:report_statuses, :name)
+    remove_index :smoking_area_statuses, :name if index_exists?(:smoking_area_statuses, :name)
+
+    change_column_null :report_statuses, :name, true
+    change_column_null :smoking_area_statuses, :name, true
+  end
+end

--- a/db/migrate/20250814071403_remove_duplicates_and_add_unique_constraint_to_status_names.rb
+++ b/db/migrate/20250814071403_remove_duplicates_and_add_unique_constraint_to_status_names.rb
@@ -1,0 +1,62 @@
+class RemoveDuplicatesAndAddUniqueConstraintToStatusNames < ActiveRecord::Migration[7.1]
+  def up
+    #report_statusesの重複処理
+    execute <<~SQL
+      WITH reps AS (
+        SELECT name, MIN(id) AS keep_id, ARRAY_AGG(id) AS ids
+        FROM report_statuses
+        GROUP BY name
+      )
+      UPDATE reports r
+      SET report_status_id = reps.keep_id
+      FROM reps
+      WHERE r.report_status_id = ANY(reps.ids)
+        AND r.report_status_id <> reps.keep_id;
+    SQL
+
+    execute <<~SQL
+      DELETE FROM report_statuses rs
+      USING (
+        SELECT id,
+               ROW_NUMBER() OVER (PARTITION BY name ORDER BY id) AS rn
+        FROM report_statuses
+      ) d
+      WHERE d.rn > 1
+        AND rs.id = d.id;
+    SQL
+
+    add_index :report_statuses, :name, unique: true unless index_exists?(:report_statuses, :name, unique: true)
+
+    #smoking_area_statusesの重複処理
+    execute <<~SQL
+      WITH reps AS (
+        SELECT name, MIN(id) AS keep_id, ARRAY_AGG(id) AS ids
+        FROM smoking_area_statuses
+        GROUP BY name
+      )
+      UPDATE smoking_areas sa
+      SET smoking_area_status_id = reps.keep_id
+      FROM reps
+      WHERE sa.smoking_area_status_id = ANY(reps.ids)
+        AND sa.smoking_area_status_id <> reps.keep_id;
+    SQL
+
+    execute <<~SQL
+      DELETE FROM smoking_area_statuses s
+      USING (
+        SELECT id,
+               ROW_NUMBER() OVER (PARTITION BY name ORDER BY id) AS rn
+        FROM smoking_area_statuses
+      ) d
+      WHERE d.rn > 1
+        AND s.id = d.id;
+    SQL
+
+    add_index :smoking_area_statuses, :name, unique: true unless index_exists?(:smoking_area_statuses, :name, unique: true)
+  end
+
+  def down
+    remove_index :smoking_area_statuses, :name if index_exists?(:smoking_area_statuses, :name)
+    remove_index :report_statuses, :name if index_exists?(:report_statuses, :name)
+  end
+end

--- a/db/migrate/20250814121357_fix_tobacco_types_kinds_and_icon_constraints.rb
+++ b/db/migrate/20250814121357_fix_tobacco_types_kinds_and_icon_constraints.rb
@@ -1,0 +1,24 @@
+class FixTobaccoTypesKindsAndIconConstraints < ActiveRecord::Migration[7.1]
+  def up
+    execute "UPDATE tobacco_types SET kinds = '電子タバコ' WHERE kinds IS NULL"
+
+    execute <<~SQL
+      UPDATE tobacco_types SET icon = CASE
+        WHEN kinds = '紙タバコ' THEN '🚬'
+        WHEN kinds = '電子タバコ' THEN '電子'
+        ELSE COALESCE (icon, 'unknown')
+      END
+      WHERE icon IS NULL;
+    SQL
+
+    change_column_null :tobacco_types, :kinds, false
+    add_index :tobacco_types, :kinds, unique: true unless index_exists?(:tobacco_types, :kinds, unique: true)
+    change_column_null :tobacco_types, :icon, false 
+  end
+
+  def down
+    change_column_null :tobacco_types, :icon, true
+    remove_index :tobacco_types, :kinds if index_exists?(:tobacco_types, :kinds)
+    change_column_null :tobacco_types, :kinds, true
+  end
+end

--- a/db/migrate/20250815110842_add_code_to_smoking_area_types_and_tighten_constraints.rb
+++ b/db/migrate/20250815110842_add_code_to_smoking_area_types_and_tighten_constraints.rb
@@ -1,0 +1,56 @@
+class AddCodeToSmokingAreaTypesAndTightenConstraints < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def up
+    execute <<~SQL
+    ALTER TABLE smoking_area_types
+    ADD COLUMN IF NOT EXISTS code varchar;
+    SQL
+
+    execute <<~SQL 
+      UPDATE smoking_area_types SET code = icon WHERE code IS NULL;
+    SQL
+
+    null_count = select_value(<<~SQL).to_i
+      SELECT COUNT(*) FROM smoking_area_types WHERE code IS NULL
+    SQL
+    if null_count > 0
+      raise StandardError, "[smoking_area_types] code に NULL が残っています（#{null_count}件）。seed などのデータ整備をしてから再実行してください。"
+    end
+
+    change_column_null :smoking_area_types, :code, false
+    change_column_null :smoking_area_types, :name, false
+    change_column_null :smoking_area_types, :icon, false
+    change_column_null :smoking_area_types, :color, false
+    
+    add_index :smoking_area_types, :code, unique: true, algorithm: :concurrently unless index_exists?(:smoking_area_types, :code, unique: true)
+
+    execute <<~SQL
+      DO $$
+      BEGIN
+        IF NOT EXISTS (
+          SELECT 1 FROM pg_constraint
+          WHERE conname = 'chk_smoking_area_types_color_hex'
+            AND conrelid = 'smoking_area_types'::regclass
+        ) THEN
+          ALTER TABLE smoking_area_types
+          ADD CONSTRAINT chk_smoking_area_types_color_hex
+          CHECK (color ~ '^#[0-9A-Fa-f]{6}$');
+        END IF;
+      END
+      $$;
+    SQL
+  end
+
+  def down
+    execute "ALTER TABLE smoking_area_types DROP CONSTRAINT IF EXISTS chk_smoking_area_types_color_hex;"
+
+    change_column_null(:smoking_area_types, :color, true) if column_exists?(:smoking_area_types, :color)
+    change_column_null(:smoking_area_types, :icon,  true) if column_exists?(:smoking_area_types, :icon)
+    change_column_null(:smoking_area_types, :name,  true) if column_exists?(:smoking_area_types, :name)
+    change_column_null(:smoking_area_types, :code,  true) if column_exists?(:smoking_area_types, :code)
+
+    remove_index :smoking_area_types, :code, if_exists: true
+    remove_column :smoking_area_types, :code if column_exists?(:smoking_area_types, :code)
+  end
+end


### PR DESCRIPTION
## 概要
既に反映済みの `schema.rb` の制約に対応する不足していたマイグレーションファイルを履歴に追加

## 背景
前PRで `schema.rb` のみ更新され、対応しているマイグレーションファイルが `main` ブランチに存在せず再現不能のため

## 内容
- マイグレーションファイル `fix_reports_columns.rb` で `reason` カラムに `null : false` を追加
- マイグレーションファイル `fix_statuses_name_not_null.rb` で以下を追加
  - `report_statuses`テーブル の `name` カラムに `null: false` を追加
  - `smoking_area_statuses` テーブルの `name` カラムに `null: false` を追加
- マイグレーションファイル `remove_duplicates_and_add_unique_constraint_to_status_names.rb` で以下を追加
  - `report_statuses` テーブルの `name` カラムにユニークインデックスを付与
  - `smoking_area_statuses` テーブルの `name` カラムにユニークインデックスを付与
- マイグレーションファイル `fix_tobacco_types_kinds_and_icon_constraints.rb` に以下を追加
  - `tobacco_types` テーブルの `kinds` カラムに `null: false` とユニークインデックスを付与
  - `tobacco_types` テーブルの `icon` カラムに `null: false` を追加
- マイグレーションファイル `add_code_to_smoking_area_types_and_tighten_constraints.rb` に以下を追加
  - `smoking_area_types` テーブルに `code` カラムを追加し、`null: false` とユニークインデックスを付与
  - `smoking_area_types` テーブルの `name` , `icon` , `color` カラムに `null: false` を追加
  - `smoking_area_types` テーブルの`color` カラムに、HEX形式のCHECK制約（ `chk_smoking_area_types_color_hex` ）を追加
 
## 動作確認
- `bin/rails db:migrate` を実行しエラーが出ないことを確認
- `bin/rails db:migrate:status | tail -n 30` を実行し該当マイグレーションファイルの状態がupになっていることを確認
- `bin/rails db:migrate RAILS_ENV=test` を実行しエラーが出ないことを確認
- `git diff -- db/schema.rb` を実行し、実質差分なしもしくはヘッダ更新程度であることを確認

## リスク/補足
- 既存データに `NULL` や重複があるとマイグレーションが失敗します。必要に応じて事前のデータクレンジングや`change_column_null` 前の `UPDATE` を行っている（該当migration内を参照）
- もし本番で巨大テーブルの場合、ユニークインデックスは `algorithm: :concurrently`（PostgreSQL）を検討（別PRでの対応可）
- このPRは migration の追加のみ。seed の更新は別PRで対応

## 関連Issue
Closes #15 