### PR TITLE
refactor(models): add basic validations and make Report polymorphic (Comment/Photo)

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -2,5 +2,5 @@ class Comment < ApplicationRecord
   belongs_to :user
   belongs_to :smoking_area
 
-  validates :content, presence: true, length: {maximum: 500}
+  validates :content, presence: true, length: {maximum: 1000}
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -2,5 +2,7 @@ class Comment < ApplicationRecord
   belongs_to :user
   belongs_to :smoking_area
 
+  has_many :reports, as: :targetable
+
   validates :content, presence: true, length: {maximum: 1000}
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -3,5 +3,8 @@ class Report < ApplicationRecord
   belongs_to :report_status
   belongs_to :targetable, polymorphic: true
 
-  validates :reason, presence: true
+  ALLOWED_TARGETS = %w[Comment Photo].freeze
+
+  validates :reason, presence: true, length: {maximum: 1000}
+  validates :targetable_type, inclusion: {in: ALLOWED_TARGETS}
 end

--- a/app/models/report_status.rb
+++ b/app/models/report_status.rb
@@ -1,2 +1,5 @@
 class ReportStatus < ApplicationRecord
+    has_many :reports
+
+    validates :name, presence: true, length: {maximum: 30}, uniqueness: true
 end

--- a/app/models/smoking_area.rb
+++ b/app/models/smoking_area.rb
@@ -8,28 +8,20 @@ class SmokingArea < ApplicationRecord
   has_many :smoking_area_tobacco_types
   has_many :tobacco_types, through: :smoking_area_tobacco_types
 
-  validates :name, presence: true, length: {maximum: 50}
-  validates :latitude, presence: true
-  validates :longitude, presence: true
-  validates :address, presence: true, length: {maximum: 100}
-  validates :latitude, numericality: { greater_than_or_equal_to: -90, less_than_or_equal_to: 90 }
-  validates :longitude, numericality: { greater_than_or_equal_to: -180, less_than_or_equal_to: 180 }
+  validates :name, presence: true, length: {maximum: 100}
+  validates :address, presence: true, length: {maximum: 255}
+  validates :detail, length: {maximum: 2000}, allow_blank: true
 
-  validate :available_time_range_is_valid
+  validates :latitude, presence: true, numericality: { greater_than_or_equal_to: -90, less_than_or_equal_to: 90 }
+  validates :longitude, presence: true, numericality: { greater_than_or_equal_to: -180, less_than_or_equal_to: 180 }
 
   enum available_time_type: {
     always: "24時間",
     business: "営業時間内",
     unknown: "不明"
-  }
+  }, _prefix: :available_time
 
-  private
+  validates :available_time_type, inclusion: {in: available_time_types.keys}, allow_nil: true
 
-  def available_time_range_is_valid
-    if available_time_start.present? && available_time_end.present?
-      if available_time_start >= available_time_end
-        errors.add(:available_time_start, "は終了時間より前である必要があります")
-      end
-    end
-  end
+  validates :is_indoor, inclusion: {in: [true, false]}, allow_nil: true
 end

--- a/app/models/smoking_area_status.rb
+++ b/app/models/smoking_area_status.rb
@@ -1,2 +1,5 @@
 class SmokingAreaStatus < ApplicationRecord
+    has_many :smoking_areas
+
+    validates :name, presence: true, length: {maximum: 30}, uniqueness: true
 end

--- a/app/models/smoking_area_type.rb
+++ b/app/models/smoking_area_type.rb
@@ -1,2 +1,8 @@
 class SmokingAreaType < ApplicationRecord
+    has_many :smoking_areas
+
+    validates :name, presence: true, length: {maximum: 30}
+    validates :code, presence: true, length: {maximum: 50}, uniqueness: true
+    validates :icon, presence: true, length: {maximum: 255}
+    validates :color, presence: true, format: { with: /\A#[0-9A-Fa-f]{6}\z/ }
 end

--- a/app/models/tobacco_type.rb
+++ b/app/models/tobacco_type.rb
@@ -2,6 +2,6 @@ class TobaccoType < ApplicationRecord
     has_many :smoking_area_tobacco_types
     has_many :smoking_areas, through: :smoking_area_tobacco_types
 
-    validates :kinds, presence: true, uniqueness: true
-    validates :icon, presence: true
+    validates :kinds, presence: true, length: {maximum: 30}, uniqueness: true
+    validates :icon, presence: true, length: {maximum: 255}
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,10 +5,8 @@ class User < ApplicationRecord
     has_many :comments
 
     validates :name, presence: true, length: {maximum: 50}
-    validates :email, presence: true, uniqueness: true, format: { with: URI::MailTo::EMAIL_REGEXP }
-    validates :password, length: {minimum: 6}, if: -> { password.present?}
+    validates :email, presence: true, length: {maximum: 255}, format: { with: URI::MailTo::EMAIL_REGEXP }, uniqueness: {case_sensitive: false}
+    validates :password, length: {minimum: 6}, allow_nil: true
 
     # validates :password, confirmation: true  フォーム実装時に追加
-
-    before_save {self.email = email.downcase}
 end

--- a/test/fixtures/report_statuses.yml
+++ b/test/fixtures/report_statuses.yml
@@ -1,7 +1,10 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  name: MyString
+  name: "対応前"
 
 two:
-  name: MyString
+  name: "対応済み"
+
+three:
+  name: "対応中"

--- a/test/fixtures/reports.yml
+++ b/test/fixtures/reports.yml
@@ -2,14 +2,12 @@
 
 one:
   user: one
-  photo: one
-  report_atatus: one
-  target_type: MyString
+  report_status: one
+  targetable: one (Photo)
   reason: MyText
 
 two:
   user: two
-  photo: two
-  report_atatus: two
-  target_type: MyString
+  report_status: two
+  targetable: two (Comment)
   reason: MyText


### PR DESCRIPTION
## 概要
モデルに基礎バリデーションを追加し、`Report` の `Comment` / `Photo` を対象にしたポリモーフィックに対応

## 背景
- すべてのモデルファイルでの基礎バリデーションの整備状況を整えるため
- `Report` の通報対象を `Comment` / `Photo` に限定したポリモーフィック設計を反映するため

## 内容
### モデルファイル
- `Comment` に以下を記述
  - `Report` のポリモーフィック関連付け（ `Report` の逆関連） `has_many :reports, as: :targetable` を追加
  - `content` の長さの上限を 500 から1000 に修正
- `Report` に以下を記述
  - `ALLOWED_TARGETS = %w[Comment Photo].freeze` で報告の対象を定数として固定
  - `reason` に長さ制限 `maximum: 1000` を追加
  - `targetable_type` に `inclusion: { in: ALLOWED_TARGETS }` で報告の対象のチェックを追加
- `ReportStatus` に以下を記述
  - `Report` との関連付け `has_many :reports` を追加
  - `name` にバリデーション `presence: true`  `length: {maximum: 30}`  `uniqueness: true`を追加
- `SmokingArea` に以下を記述
  - `name` の長さを `length: {maximum: 100}` に変更
  - `address` の長さを `length: {maximum: 255}` に変更
  - `detail` に長さ `length: {maximum: 2000}` と`null` 及び空文字を許容する `allow_blank: true` を追加
  - `latitude` / `longitude` は各属性で `presence` / `numericality` を同時評価するように修正
  - `enum available_time_type` に接頭辞 `_prefix` を追記
  - `available_time_type` にバリデーション `inclusion: {in: available_time_types.keys}, allow_nil: true` 追加
  - `is_indoor` にバリデーション `inclusion: {in: [true, false]}, allow_nil: true` を追加
  - カスタムバリデーション `available_time_range_is_valid` を削除
- `SmokingAreaStatus` に以下を記述
  - `SmokingArea` との関連付け `has_many :smoking_areas` を追加
  - `name` カラムにバリデーション `presence: true, length: {maximum: 30}, uniqueness: true` を追加
- `SmokingAreaType` に以下を記述
  - `SmokingArea` との関連付け `has_many :smoking_areas` を追加
  - `name` カラムにバリデーション `presence: true, length: {maximum: 30}` を追加
  - `code` カラムにバリデーション `presence: true, length: {maximum: 50}, uniqueness: true` を追加
  - `icon` カラムにバリデーション `presence: true, length: {maximum: 255}` を追加
  - `color` カラムにバリデーション `presence: true, format: { with: /\A#[0-9A-Fa-f]{6}\z/ }` を追加
- `TobaccoType` に以下を記述
  - `kinds` カラムに `length: {maximum: 30}` を追加
  - `icon` カラムに `length: {maximum: 255}` を追加
- `User` に以下を記述
  - `email` カラムに `length: {maximum: 255}` を追加し `uniqueness: true` を `uniqueness: {case_sensitive: false}`  に修正
  - `password` カラムの `if: -> { password.present?}` を削除し `allow_nil: true` を追加

### fixturesファイル
- `report_statuses.yml` に以下を記述
  - `one: "対応前"` , `two: "対応済み"` , `three: "対応中"` に変更
- `reports.yml` で以下を修正
  -  `photo: one` と `photo: two` を削除
  - `one: target_type: MyString` を `targetable: one (Photo)` に修正
  - `two: target_type: MyString` を `targetable: two (Comment)` に修正

## 動作確認
```ruby
u  = User.first
rs = ReportStatus.first
c  = Comment.first

# 前提: User / ReportStatus / Comment が1件以上存在していること
r = Report.new(user: User.first, report_status: ReportStatus.first, targetable: Comment.first, reason: "通報テスト")
r.valid?
=> true が出力されることを確認

st = SmokingAreaStatus.first; ty = SmokingAreaType.first
SmokingArea.new(user: u, smoking_area_status: st, smoking_area_type: ty,
                name: "駅前", address: "東京都…", latitude: 90, longitude: 180,
                available_time_type: "always").valid? 
# => true が出力されることを確認

SmokingArea.new(user: u, smoking_area_status: st, smoking_area_type: ty,
                name: "A", address: "B", latitude: 91, longitude: 0).valid?
# => false が出力されることを確認
```

## 影響範囲
- アプリ機能/API : 影響なし
- データ移行 : 不要
- DB変更なし

## 補足
- 営業時間のカスタムバリデーションは別PRで検討及び実装予定
- ON DELETEポリシーは別Issueで整理予定