### PR TITLE
feat(smoking_area): when SmokingArea is deleted, delete photos and ActiveStorage blobs

### DIFF
--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -1,6 +1,6 @@
 class Photo < ApplicationRecord
   belongs_to :smoking_area
-  has_one_attached :image
+  has_one_attached :image, dependent: :purge_later
   has_many :reports, as: :targetable
 
   validates :image, presence: true

--- a/app/models/smoking_area.rb
+++ b/app/models/smoking_area.rb
@@ -3,7 +3,7 @@ class SmokingArea < ApplicationRecord
   belongs_to :smoking_area_status
   belongs_to :smoking_area_type
 
-  has_many :photos
+  has_many :photos, dependent: :destroy
   has_many :comments
   has_many :smoking_area_tobacco_types
   has_many :tobacco_types, through: :smoking_area_tobacco_types

--- a/db/migrate/20250921123000_add_on_delete_cascade_to_comments_on_smoking_area_foreign_key.rb
+++ b/db/migrate/20250921123000_add_on_delete_cascade_to_comments_on_smoking_area_foreign_key.rb
@@ -1,0 +1,11 @@
+class AddOnDeleteCascadeToCommentsOnSmokingAreaForeignKey < ActiveRecord::Migration[7.1]
+  def up
+    remove_foreign_key :comments, :smoking_areas if foreign_key_exists?(:comments, :smoking_areas)
+    add_foreign_key :comments, :smoking_areas, on_delete: :cascade
+  end
+
+  def down
+    remove_foreign_key :comments, :smoking_areas
+    add_foreign_key :comments, :smoking_areas
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_08_23_111154) do
+ActiveRecord::Schema[7.1].define(version: 2025_09_21_123000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -146,7 +146,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_08_23_111154) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
-  add_foreign_key "comments", "smoking_areas"
+  add_foreign_key "comments", "smoking_areas", on_delete: :cascade
   add_foreign_key "comments", "users"
   add_foreign_key "photos", "smoking_areas"
   add_foreign_key "reports", "report_statuses"


### PR DESCRIPTION
## 概要
喫煙所削除時に写真（Blob）とコメントを削除

## 背景
- 喫煙所削除時に削除される喫煙所に関する写真も削除し、同時にBlobも削除するため
- 喫煙所削除時に削除される喫煙所に関するコメントをDBで削除するため

## 内容
- `SmokingArea` モデルの `has_many :photos` に `dependent: :destroy`を追加
- `Photo` モデルの `has_one_attached :image` にオプションとして `dependent: :purge_later` を追加
- マイグレーションファイルを新規作成し、`comments` テーブルにある `smoking_areas` テーブルの外部キーを `on_delete: :cascade` に変更

## 動作確認
前提：①写真付きの SmokingArea が1件以上存在 
　　　②“コメントのみ”を持つ SmokingArea が1件以上存在
　　　③ Photo に image が添付されていること（該当 Photo に Attachment / Blob が存在）
- `bin/rails c` で以下の動作を確認
```ruby
# photo
require "stringio"; sleep_sec = 5
uid = User.first.id; sid = SmokingAreaStatus.first.id; tid = SmokingAreaType.first.id

sa = SmokingArea.new(user_id: uid, smoking_area_status_id: sid, smoking_area_type_id: tid,
                     name: "tmp", latitude: 0.0, longitude: 0.0, is_indoor: false, address: "tmp")
sa.available_time_type = :always
sa.save!(validate:false)

ph = Photo.new(smoking_area_id: sa.id); ph.save!(validate:false)
ph.image.attach(io: StringIO.new("x"), filename: "tmp.jpg", content_type: "image/jpeg")

att_id = ph.image.attachment.id; blob_id = ph.image.blob.id; pid = ph.id

sa.destroy
sleep sleep_sec

[ 
  ActiveStorage::Attachment.exists?(att_id),
  ActiveStorage::Blob.exists?(blob_id),
  Photo.exists?(pid)
]
# => [ false, false, false ] が出力されることを確認

# comment
uid = User.first.id; sid = SmokingAreaStatus.first.id; tid = SmokingAreaType.first.id

sb = SmokingArea.new(user_id: uid, smoking_area_status_id: sid, smoking_area_type_id: tid,
                     name: "tmp", latitude: 0.0, longitude: 0.0, is_indoor: false, address: "tmp")
sb.available_time_type = :always
sb.save!(validate:false)

Comment.create!(user_id: uid, smoking_area_id: sb.id, content: "tmp")

before = Comment.where(smoking_area_id: sb.id).count
SmokingArea.delete(sb.id)
after  = Comment.where(smoking_area_id: sb.id).count
[ before > 0, after ]
# => [ (before > 0), 0 ] が出力されることを確認

# photo + comment
require "stringio"
sleep_step = 0.5; timeout = 30
uid = User.first.id; sid = SmokingAreaStatus.first.id; tid = SmokingAreaType.first.id

sy = SmokingArea.new(user_id: uid, smoking_area_status_id: sid, smoking_area_type_id: tid,
                     name: "tmp", latitude: 0.0, longitude: 0.0, is_indoor: false, address: "tmp")
sy.available_time_type = :always
sy.save!(validate:false)

ph = Photo.new(smoking_area_id: sy.id); ph.save!(validate:false)
ph.image.attach(io: StringIO.new("y"), filename: "tmp2.jpg", content_type: "image/jpeg")
Comment.create!(user_id: uid, smoking_area_id: sy.id, content: "tmp")

att_id = ph.image.attachment.id; blob_id = ph.image.blob.id; pid = ph.id

sy.destroy
deadline = Time.now + timeout
loop do
  break if (!ActiveStorage::Attachment.exists?(att_id) &&
            !ActiveStorage::Blob.exists?(blob_id) &&
            !Photo.exists?(pid)) || Time.now >= deadline
  sleep sleep_step
end

[ 
  Photo.exists?(pid),
  ActiveStorage::Attachment.exists?(att_id),
  ActiveStorage::Blob.exists?(blob_id),
  Comment.where(smoking_area_id: sy.id).count
]
# => [false, false, false, 0] が出力されることを確認
```
- `schema.rb` に  `add_foreign_key "comments", "smoking_areas", on_delete: :cascade` の記述があることを確認

## 影響範囲
- アプリ機能/API：なし
- データ移行：なし
- DB変更：あり
  - `comments.smoking_area_id` のFKを `ON DELETE CASCADE` に変更
  - デプロイ時に `rails db:migrate` 必須
  - ロールバック可（逆マイグレーションで元の制約に戻せる）

## 関連Issue
Closes #24 