### PR TITLE
chore(db): change address to nullable in smoking_areas

### DIFF
--- a/app/models/smoking_area.rb
+++ b/app/models/smoking_area.rb
@@ -9,7 +9,7 @@ class SmokingArea < ApplicationRecord
   has_many :tobacco_types, through: :smoking_area_tobacco_types
 
   validates :name, presence: true, length: {maximum: 100}
-  validates :address, presence: true, length: {maximum: 255}
+  validates :address, length: {maximum: 255}
   validates :detail, length: {maximum: 2000}, allow_blank: true
 
   validates :latitude, presence: true, numericality: { greater_than_or_equal_to: -90, less_than_or_equal_to: 90 }

--- a/db/migrate/20251002101244_change_address_null_on_smoking_areas.rb
+++ b/db/migrate/20251002101244_change_address_null_on_smoking_areas.rb
@@ -1,0 +1,5 @@
+class ChangeAddressNullOnSmokingAreas < ActiveRecord::Migration[7.1]
+  def change
+    change_column_null :smoking_areas, :address, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_09_21_123000) do
+ActiveRecord::Schema[7.1].define(version: 2025_10_02_101244) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -119,7 +119,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_09_21_123000) do
     t.time "available_time_start"
     t.time "available_time_end"
     t.text "detail"
-    t.string "address", null: false
+    t.string "address"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["smoking_area_status_id"], name: "index_smoking_areas_on_smoking_area_status_id"


### PR DESCRIPTION
## 概要
`smoking_areas` テーブルの `address` カラムを `NOT NULL` からNULL許容に変更

## 背景
- 喫煙所の住所に関してユーザーからの入力は受け付けない実装により、`NOT NULL` での運用は意図とは不一致なため
- 将来的に住所検索などでの運用・表示には有用だが、MVPでは必須ではないため

## 内容
- マイグレーションファイル `ChangeAddressNullOnSmokingAreas` を作成し、`change_column_null :smoking_areas, :address, true` を記述
- モデルファイル `smoking_area.rb` でのバリデーション `validates :address` の引数 `presence: true` の記述を削除

## 動作確認
- `bin/rails db:migrate` を実行し、エラーが出力されないことを確認
- `bin/rails db:seed` を実行し、エラーが出力されないことを確認
- `schema.rb` の `smoking_areas` テーブル `t.string "address"` カラムに `null: false` の記述がないことを確認
```ruby
ActiveRecord::Base.transaction do
  require "securerandom"

  sa = SmokingArea.first or raise "No SmokingArea seed. Run: bin/rails db:seed"

  # 1) 既存レコードを address: nil に更新できること
  sa.update!(address: nil)
  raise "Update to nil failed" unless sa.reload.address.nil?

  # 2) address: nil で新規作成できること（既存を複製して最小変更）
  attrs = sa.attributes.except("id", "created_at", "updated_at")
  attrs["address"] = nil
  # ユニーク衝突の可能性を下げる微調整（あれば）
  attrs["latitude"]  = attrs["latitude"].to_f  + 0.000001  if attrs.key?("latitude")
  attrs["lat"]       = attrs["lat"].to_f       + 0.000001  if attrs.key?("lat")
  attrs["longitude"] = attrs["longitude"].to_f + 0.000001  if attrs.key?("longitude")
  attrs["lng"]       = attrs["lng"].to_f       + 0.000001  if attrs.key?("lng")
  attrs["name"]      = "#{attrs["name"]}-tmp-#{SecureRandom.hex(4)}" if attrs.key?("name")

  tmp = SmokingArea.create!(attrs)
  raise "Create with nil address failed" unless tmp.persisted? && tmp.address.nil?

  puts "OK: address nullable on update & create（すべて検証済み／この後ロールバック）"
  raise ActiveRecord::Rollback
end
```

## 影響範囲
- アプリ機能/API：影響なし
- データ移行：不要
- DB変更：あり
  - `smoking_areas` テーブルの `address` カラムを NULL許容に変更

## 関連Issue
Closes #29 