### PR TITLE
feat:add openapi skeleton

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,75 @@
+openapi: 3.0.3
+
+info:
+  title: Smoking Area Map API
+  version: 0.1.0
+  description: >
+    喫煙所マップアプリの v0.1 API 定義。
+    smoking_areas / tobacco_types の閲覧系エンドポイントのみを含む。
+
+servers:
+  - url: http://localhost:3000
+    description: Local development
+
+paths:
+  /v1/smoking_areas:
+    get:
+      summary: List smoking areas
+      description: 現在地または任意地点周辺の喫煙所一覧を返す。
+      tags: [smoking_areas]
+      parameters: []
+      responses:
+        '200':
+          description: OK
+        '400':
+          description: invalid_param
+        '500':
+          description: internal_error
+
+  /v1/smoking_areas/{id}:
+    get:
+      summary: Get smoking area
+      description: 喫煙所1件の詳細情報を返す。
+      tags: [smoking_areas]
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+        '404':
+          description: not_found
+        '500':
+          description: internal_error
+
+  /v1/tobacco_types:
+    get:
+      summary: List tobacco types
+      description: フィルタUI用のタバコ種類マスタを返す。
+      tags: [tobacco_types]
+      parameters: []
+      responses:
+        '200':
+          description: OK
+        '500':
+          description: internal_error
+
+components:
+  schemas:
+    SmokingArea:
+      type: object
+      description: 喫煙所1件分の情報
+      properties: {}
+
+    TobaccoType:
+      type: object
+      description: タバコ種類マスタ1件分の情報
+      properties: {}
+
+    ErrorResponse:
+      type: object
+      description: 共通エラーレスポンス
+      properties: {}


### PR DESCRIPTION
## 概要
OpenAPI 3.0.3 形式のAPIスケルトンを追加し、喫煙所マップアプリ向けの v0.1 API 定義（閲覧系エンドポイントのみ）を追加。

## 背景
API仕様の骨子（v0.1）を作成してドキュメント化するため。

## 内容
- Notionに「API設計」ページを作成し以下を記述
    - 共通ルール（バージョニング / ページネーション / エラー形式など）
    - MVPで使用するエンドポイント（GET/v1/smoking_area, smoking_area/{id}, tobacco_types）を定義
    - 変更履歴（Change log）と決定ログ（Decision log）
- `/docs/openapi.yaml` にひな形を追加
- READMEに以下を追記
    - Notionの「API設計」ページURL
    - `/docs/openapi.yaml` のパス

## 動作確認
- 仕様ドキュメント追加のみの差分のため、サーバ起動やエンドポイント実行による動作確認は未実施
- 静的ファイルの追加以外のアプリコード変更は diff に含まれていないため、アプリ側の統合確認は未実施

## 影響範囲
- アプリ機能/API：影響なし
- データ移行：不要
- DB変更：なし

## 関連Issue
Closes #28 