### PR TITLE
add controller design documentation in the repository

### DIFF
--- a/docs/controller_design.md
+++ b/docs/controller_design.md
@@ -1,0 +1,41 @@
+# v0.1 コントローラー設計
+
+## 対象エンドポイント
+- GET /v1/smoking_areas
+- GET /v1/smoking_areas/{id}
+- GET /v1/tobacco_types
+
+## Api::V1::SmokingAreasController
+
+### index
+- Params
+    - lat, lng (必須)
+    - tobacco_type_ids[], radius_m, q, sort, page, per_page
+
+- 処理の流れ
+    1.パラメータの型・範囲をバリデーション(lat / lng, radius_m, sort, page, per_page など。不正時は 400 invalid_param)
+    2.tobacco_type_ids[]（タバコ種別）が指定されていれば、中間テーブル経由で該当喫煙所だけをDB側の絞り込みで残す
+    3.q が指定されていれば、name の部分一致でさらに絞り込み
+    4.位置情報(lat, lng)と radius_m で距離(distance_m)を計算し、範囲内(既定:1000m, [100, 3000] でclamp)の喫煙所に絞る
+    5.sort で distance_asc が指定されている場合は、distance_m の昇順で並び替え、page / per_page でページネーションして返す
+
+### show
+- Params
+  - id : integer(必須、path)
+
+- 処理の流れ
+    1.URLパスの id から対象の喫煙所を1件取得する
+    2.見つからない場合は 404 not_found エラーを返す
+    3.取得した喫煙所の位置(lat, lng)と基本情報（name, is_indoor, detail, tobacco_types[{id, name, icon}]）をJSONで返す
+
+
+## Api::V1::TobaccoTypesController
+
+### index
+- Params
+    - クエリパラメータはなし
+
+- 処理の流れ
+    1.タバコ種別マスタを全件取得する
+    2.display_order 昇順で並び替える（紙タバコ → 電子タバコ の順）
+    3.{id, name, icon} を JSON の配列として返す（フィルタUIでアイコンを表示する前提）


### PR DESCRIPTION
## 概要
v0.1 のコントローラー設計ドキュメントを追加し、GET系の閲覧エンドポイントの振る舞い（パラメータ・処理フロー）を定義

## 背景
コントローラー実装前に設計ドキュメントを作成し、挙動を明確化するため

## 内容
- READMEに以下を追記
    - Notionの「コントローラー設計」ページURL
    - `docs/controller_design.md` のパス

### Notion
- 「コントローラー設計」ページを新規作成
- 各 Controller#Action ごとに以下を記述
    - Controller#Action / Route(API設計リンク) / Auth
    - Params(キー・型・必須/制約) / 処理の流れ
    - 成功HTTPステータス / 代表エラー / Notes

### リポジトリ
- `docs/controller_design.md` を新規作成
- v0.1 で実装する以下3エンドポイントのコントローラー設計を追加
    - `Api::V1::SmokingAreasController#index`, (GET /v1/smoking_areas)
    - `Api::V1::SmokingAreasController#show`, (GET /v1/smoking_areas/{id})
    - `Api::V1::TobaccoTypesController#index`, (GET /v1/tobacco_types)
- 各アクションに Params / 処理の流れ を定義

## 動作確認
ドキュメント追加のみの差分のため、アプリ起動やエンドポイント実行による動作確認は未実施

## 影響範囲
- アプリ機能/API：影響なし
- データ移行：不要
- DB変更：なし

## 関連Issue
Closes #33 