### PR TITLE
feat: add v1 smoking_areas index endpoint

### DIFF
--- a/app/controllers/v1/smoking_areas_controller.rb
+++ b/app/controllers/v1/smoking_areas_controller.rb
@@ -1,0 +1,15 @@
+class V1::SmokingAreasController < ApplicationController
+  def index
+    smoking_areas = SmokingArea.order(:id).includes(:tobacco_types)
+
+    render json: smoking_areas.map do |smoking_area| 
+      {
+        id:   smoking_area.id,
+        name: smoking_area.name,
+        latitude:  smoking_area.latitude,
+        longitude: smoking_area.longitude,
+        tobacco_type_ids: smoking_area.tobacco_types.order(:display_order).pluck(:id)
+      }
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   namespace :v1 do
     resources :tobacco_types, only: [:index]
+    resources :smoking_areas, only: [:index]
   end
 
   # Health check

--- a/spec/requests/v1/smoking_areas_spec.rb
+++ b/spec/requests/v1/smoking_areas_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe "V1::SmokingAreas", type: :request do
+  describe "GET /v1/smoking_areas" do
+    it "returns information necessary to display smoking areas" do
+
+      electronic = TobaccoType.create!(name: "電子タバコ", icon: "electronic cigarette", display_order: 2)
+      paper      = TobaccoType.create!(name: "紙タバコ",   icon: "cigarette",            display_order: 1)
+
+      smoking_area1 = SmokingArea.create!(name: "新宿東口喫煙所",       latitude: 36.666333,  longitude: 135.343434)
+      smoking_area2 = SmokingArea.create!(name: "鳥貴族町田北口店",     latitude: 35.123456,  longitude: 134.987654)
+      smoking_area3 = SmokingArea.create!(name: "ニトリモール相模原1F", latitude: 35.555555,  longitude: 139.777333)
+
+      SmokingAreaTobaccoType.create!(smoking_area: smoking_area1, tobacco_type: paper)
+      SmokingAreaTobaccoType.create!(smoking_area: smoking_area1, tobacco_type: electronic)
+      SmokingAreaTobaccoType.create!(smoking_area: smoking_area2, tobacco_type: paper)
+      SmokingAreaTobaccoType.create!(smoking_area: smoking_area2, tobacco_type: electronic)
+      SmokingAreaTobaccoType.create!(smoking_area: smoking_area3, tobacco_type: electronic)
+
+      get "/v1/smoking_areas"
+
+      expect(response).to have_http_status(:ok)
+
+      json = JSON.parse(response.body)
+
+      expect(json.size).to eq 3
+      expect(json.map { |smoking_area_json| smoking_area_json["name"] }).to eq [
+        smoking_area1.name,
+        smoking_area2.name,
+        smoking_area3.name
+      ]
+
+      first = json.first
+      expect(first["tobacco_type_ids"]).to eq [paper.id, electronic.id]
+
+      json.each do |smoking_area_json|
+        expect(smoking_area_json.keys.sort).to eq %w[id name latitude longitude tobacco_type_ids].sort
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要
地図上に喫煙所を表示するための一覧 API エンドポイント GET /v1/smoking_areas を追加

## 背景
喫煙所を表示するための API が必要なため

## 内容
- `config/routes.rb` の `namespace :v1` に、`resources :smoking_areas, only: :index` を追加
- `app/controllers/v1/smoking_areas_controller.rb` を新規作成
    - index アクションで `SmokingArea.order(:id).includes(:tobacco_types)` を取得し、
      `id` / `name` / `latitude` / `longitude` / `tobacco_type_ids` のみを含む JSON 配列として返すように実装
    - `tobacco_type_ids` は `tobacco_types` を `display_order` 昇順でソートし `id` を `pluck` で取得した整数IDの配列
 - `spec/requests/v1/smoking_areas_spec.rb` を新規作成
    - 2件の `TobaccoType` /  3件の `SmokingArea` / `SmokingAreaTobaccoType` で各喫煙所に紐づくタバコの種類を作成し、
      HTTPステータスコード / 件数 / 順序 / フィールド構成を検証する request spec を実装

## 動作確認
- `bin/rails routes | grep v1.*smoking_areas` を実行しルーティングが追加されていることを確認
- `bin/rails s` で `curl -i -H "Accept: application/json" http://localhost:3000/v1/smoking_areas` を実行し、
    HTTPステータスコード 200 と `id` / `name` / `latitude` / `longitude` / `tobacco_type_ids` を含むJSONレスポンスが返ってくることを確認
- `bundle exec rspec spec/requests/v1/smoking_areas_spec.rb` が成功することを確認

## 影響範囲
- アプリ機能/API：影響あり（具体：`GET /v1/smoking_areas` エンドポイントを追加）
- データ移行：不要
- DB変更：なし

## 関連Issue
Closes #44 