### PR TITLE
fix(controller): build smoking_areas JSON correctly

### DIFF
--- a/app/controllers/v1/smoking_areas_controller.rb
+++ b/app/controllers/v1/smoking_areas_controller.rb
@@ -2,7 +2,7 @@ class V1::SmokingAreasController < ApplicationController
   def index
     smoking_areas = SmokingArea.order(:id).includes(:tobacco_types)
 
-    render json: smoking_areas.map do |smoking_area| 
+    render json: smoking_areas.map { |smoking_area| 
       {
         id:   smoking_area.id,
         name: smoking_area.name,
@@ -10,6 +10,6 @@ class V1::SmokingAreasController < ApplicationController
         longitude: smoking_area.longitude,
         tobacco_type_ids: smoking_area.tobacco_types.order(:display_order).pluck(:id)
       }
-    end
+    }
   end
 end


### PR DESCRIPTION
## 概要
前PRで `/v1/smoking_areas` の JSON 組み立てにミスがあり、`tobacco_type_ids` が返っていなかったため修正する

## 背景
地図表示用の喫煙所一覧 API のレスポンスを、仕様どおり `tobacco_type_ids` を含む形に揃えるため

## 内容
- 前PRで `render json: smoking_areas.map do ... end` と書いてしまい、
  ブロックが `map` ではなく `render` に付いていた
- その影響で `tobacco_type_ids` が JSON に含まれず、テーブルカラムだけが返っていた
- `render json: smoking_areas.map { ... }` に修正して、
  各喫煙所ごとに `tobacco_type_ids` を含む JSON を返すようにした

## 動作確認
- `bundle exec rspec spec/requests/v1/smoking_areas_spec.rb` を実行し成功を確認
- `curl -i -H "Accept: application/json" http://localhost:3000/v1/smoking_areas` を実行し、 
  レスポンスのJSONに `tobacco_type_ids` を含むことを確認

## 影響範囲
- アプリ機能/API：影響あり（`GET /v1/smoking_areas` のレスポンスJSONのみ修正）
- データ移行：不要
- DB変更：なし

## 関連Issue
Closes #44 

