### PR TITLE
feat: add tobacco_type and query filters to smoking_areas index

### DIFF
--- a/app/controllers/v1/smoking_areas_controller.rb
+++ b/app/controllers/v1/smoking_areas_controller.rb
@@ -2,6 +2,25 @@ class V1::SmokingAreasController < ApplicationController
   def index
     smoking_areas = SmokingArea.order(:id).includes(:tobacco_types)
 
+    # たばこ種別フィルタ（tobacco_type_id が指定された場合）
+    if params[:tobacco_type_id].present?
+      smoking_areas = smoking_areas
+        .joins(:tobacco_types)
+        .where(tobacco_types: { id: params[:tobacco_type_id] })
+    end
+
+    # 名前検索（query が指定されていて、実質的な文字がある場合）
+    if params[:query].present?
+      query = params[:query].squish  # 前後の空白 + 連続空白 + 全角スペースも正規化
+      if query != ""
+        smoking_areas = smoking_areas.where("smoking_areas.name ILIKE ?", "%#{query}%")
+      end
+    end
+
+    # join で重複する可能性があるので distinct、
+    # かつ既存仕様どおり id 昇順で返す
+    smoking_areas = smoking_areas.distinct.order(:id)
+
     render json: (smoking_areas.map do |smoking_area|
       {
         id:   smoking_area.id,

--- a/spec/requests/v1/smoking_areas_spec.rb
+++ b/spec/requests/v1/smoking_areas_spec.rb
@@ -39,6 +39,92 @@ RSpec.describe "V1::SmokingAreas", type: :request do
         expect(smoking_area_json.keys.sort).to eq %w[id name latitude longitude tobacco_type_ids].sort
       end
     end
+
+    it "filters smoking areas by tobacco_type_id" do
+      electronic = TobaccoType.create!(name: "電子タバコ", icon: "electronic cigarette", display_order: 2)
+      paper      = TobaccoType.create!(name: "紙タバコ",   icon: "cigarette",            display_order: 1)
+      
+      smoking_area1 = SmokingArea.create!(name: "新宿東口喫煙所",       latitude: 36.666333,  longitude: 135.343434)
+      smoking_area2 = SmokingArea.create!(name: "鳥貴族町田北口店",     latitude: 35.123456,  longitude: 134.987654)
+      smoking_area3 = SmokingArea.create!(name: "ニトリモール相模原1F", latitude: 35.555555,  longitude: 139.777333)
+
+      SmokingAreaTobaccoType.create!(smoking_area: smoking_area1, tobacco_type: paper)
+      SmokingAreaTobaccoType.create!(smoking_area: smoking_area1, tobacco_type: electronic)
+      SmokingAreaTobaccoType.create!(smoking_area: smoking_area2, tobacco_type: paper)
+      SmokingAreaTobaccoType.create!(smoking_area: smoking_area2, tobacco_type: electronic)
+      SmokingAreaTobaccoType.create!(smoking_area: smoking_area3, tobacco_type: electronic)
+
+      get "/v1/smoking_areas", params: { tobacco_type_id: paper.id }
+
+      expect(response).to have_http_status(:ok)
+
+      json = JSON.parse(response.body)
+
+      # 紙タバコに紐づく喫煙所だけが返ること
+      expect(json.size).to eq 2
+      expect(json.map { |smoking_area_json| smoking_area_json["name"] }).to match_array [
+        smoking_area1.name,
+        smoking_area2.name
+      ]
+      json.each do |smoking_area_json|
+        expect(smoking_area_json["tobacco_type_ids"]).to include(paper.id)
+      end
+    end
+
+    it "filters smoking areas by query on name" do
+      electronic = TobaccoType.create!(name: "電子タバコ", icon: "electronic cigarette", display_order: 2)
+      paper      = TobaccoType.create!(name: "紙タバコ",   icon: "cigarette",            display_order: 1)
+      
+      shinjuku_east   = SmokingArea.create!(name: "新宿東口喫煙所",    latitude: 36.666333, longitude: 135.343434)
+      shinjuku_sanchome = SmokingArea.create!(name: "新宿三丁目喫煙所", latitude: 36.666334, longitude: 135.343435)
+      machida_north   = SmokingArea.create!(name: "町田駅北口喫煙所",  latitude: 35.123456, longitude: 134.987654)
+
+      [shinjuku_east, shinjuku_sanchome, machida_north].each do |area|
+        SmokingAreaTobaccoType.create!(smoking_area: area, tobacco_type: paper)
+        SmokingAreaTobaccoType.create!(smoking_area: area, tobacco_type: electronic)
+      end
+
+      get "/v1/smoking_areas", params: { query: "新宿" }
+
+      expect(response).to have_http_status(:ok)
+
+      json = JSON.parse(response.body)
+
+      # name に「新宿」を含む喫煙所だけが返ること
+      expect(json.size).to eq 2
+      expect(json.map { |smoking_area_json| smoking_area_json["name"] }).to match_array [
+        shinjuku_east.name,
+        shinjuku_sanchome.name
+      ]
+    end
+
+    it "filters smoking areas by both tobacco_type_id and query" do
+      electronic = TobaccoType.create!(name: "電子タバコ", icon: "electronic cigarette", display_order: 2)
+      paper      = TobaccoType.create!(name: "紙タバコ",   icon: "cigarette",            display_order: 1)
+      
+      shinjuku_both = SmokingArea.create!(name: "新宿東口喫煙所",    latitude: 36.666333, longitude: 135.343434)
+      shinjuku_electronic_only = SmokingArea.create!(name: "新宿西口喫煙所", latitude: 36.666334, longitude: 135.343435)
+      machida_paper_only = SmokingArea.create!(name: "町田駅北口喫煙所",  latitude: 35.123456, longitude: 134.987654)
+
+      # 新宿東口: 紙 + 電子
+      SmokingAreaTobaccoType.create!(smoking_area: shinjuku_both, tobacco_type: paper)
+      SmokingAreaTobaccoType.create!(smoking_area: shinjuku_both, tobacco_type: electronic)
+      # 新宿西口: 電子のみ
+      SmokingAreaTobaccoType.create!(smoking_area: shinjuku_electronic_only, tobacco_type: electronic)
+      # 町田北口: 紙のみ
+      SmokingAreaTobaccoType.create!(smoking_area: machida_paper_only, tobacco_type: paper)
+
+      get "/v1/smoking_areas", params: { tobacco_type_id: paper.id, query: "新宿" }
+
+      expect(response).to have_http_status(:ok)
+
+      json = JSON.parse(response.body)
+
+      # 「新宿」を含み、かつ紙タバコに対応している喫煙所だけが返ること
+      expect(json.size).to eq 1
+      expect(json.first["name"]).to eq shinjuku_both.name
+      expect(json.first["tobacco_type_ids"]).to include(paper.id)
+    end
   end
 
   describe "GET /v1/smoking_areas/:id" do


### PR DESCRIPTION
## 概要
tobacco_type_id と query のパラメータに応じて SmokingArea を絞り込んで返す

## 背景
- たばこ種別や名称での絞り込み検索機能を追加するため
- 既存のレスポンスフィールド・順序を壊さずに検索機能を追加するため

## 内容
- `app/controllers/v1/smoking_areas_controller.rb`
  - `params[:tobacco_type_id]` を受け取り、指定がある場合はその `tobacco_type` に紐づく `SmokingArea` のみを返す処理を追加
  - `params[:query]` を受け取り、指定がある場合は `smoking_areas.name` を部分一致で検索する処理を追加
  - `tobacco_type_id` と `query` が両方指定された場合、両方の条件を満たす `SmokingArea` のみを返す（AND条件）ように組み合わせる
  - パラメータが無い、または空のときは現状通り全件を返すロジックを維持
  - `includes(:tobacco_types)` を維持したまま `tobacco_type_ids` を返す実装とし、N+1 が発生しないようクエリを最適化
  - レスポンスのフィールドと配列の順序は現状の index と同一に保つ（既存仕様を壊さない）
  - `tobacco_type_id` で `join` した結果が重複する場合に備え、必要に応じて `distinct` で重複を除外
  - `params[:query].squish` で `query` の前後の空白や連続した空白を正規化（全角スペースも含む）
- request spec 追加
  - `tobacco_type_id` 指定時に該当の喫煙所のみ返ること、および返ってくる JSON の `tobacco_type_ids` に指定 id が含まれることを確認するテストを追加
  - `query` 指定時に `name` に部分一致する喫煙所のみ返ることを確認するテストを追加
  - `tobacco_type_id` / `query` の両方指定時に AND 条件で絞り込まれることを確認するテストを追加

## 動作確認
- `bin/rails s` でサーバーを起動しブラウザで以下の指定のパスを叩き返ってくるJSONを確認
  - `http://localhost:3000/v1/smoking_areas` でパラメータが無い/空の場合は従来通り全件が返ることを確認
  - `http://localhost:3000/v1/smoking_areas?tobacco_type_id=1` で `tobacco_type_id`のみ指定したリクエストで、
     指定した `tobacco_type` に紐づく `SmokingArea` 一覧が返ることを確認
  - `http://localhost:3000/v1/smoking_areas?query=新宿` で `smoking_areas.name` に対して部分一致でヒットする `SmokingArea` が返ることを確認
  - `http://localhost:3000/v1/smoking_areas?query= 新宿 ` で `query` の前後に半角スペースを含んだリクエストでも`smoking_areas.name` に対して部分一致でヒットする `SmokingArea` が返ることを確認
  - `http://localhost:3000/v1/smoking_areas?query=　新宿　` で `query` の前後に全角スペースを含んだリクエストでも `name` に部分一致する `SmokingArea` が返ることを確認
  - `http://localhost:3000/v1/smoking_areas?tobacco_type_id=1&query=新宿` で `tobacco_type_id` と `query` の両条件を満たす `SmokingArea` のみが返ることを確認

## 影響範囲
- アプリ機能/API：影響あり（具体：`GET /v1/smoking_areas` に `tobacco_type_id` による絞り込みと `query` による `name` 検索が追加される）
- データ移行：不要
- DB変更：なし

## 関連Issue
Closes #49 