### PR TITLE
chore: update frontend package-lock for WSL node

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1283,9 +1283,9 @@
       ]
     },
     "node_modules/@swc/core": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.5.tgz",
-      "integrity": "sha512-VRy+AEO0zqUkwV9uOgqXtdI5tNj3y3BZI+9u28fHNjNVTtWYVNIq3uYhoGgdBOv7gdzXlqfHKuxH5a9IFAvopQ==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.6.tgz",
+      "integrity": "sha512-BpSCKSwE5DG4N4Um+ZZwvJzJ/4iyMVlzvhJQoR0wJSgccca9ES3+P/7SbPxTM/jtV9vE1llfLPphw+Y+MFhnZg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -1301,16 +1301,16 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.15.5",
-        "@swc/core-darwin-x64": "1.15.5",
-        "@swc/core-linux-arm-gnueabihf": "1.15.5",
-        "@swc/core-linux-arm64-gnu": "1.15.5",
-        "@swc/core-linux-arm64-musl": "1.15.5",
-        "@swc/core-linux-x64-gnu": "1.15.5",
-        "@swc/core-linux-x64-musl": "1.15.5",
-        "@swc/core-win32-arm64-msvc": "1.15.5",
-        "@swc/core-win32-ia32-msvc": "1.15.5",
-        "@swc/core-win32-x64-msvc": "1.15.5"
+        "@swc/core-darwin-arm64": "1.15.6",
+        "@swc/core-darwin-x64": "1.15.6",
+        "@swc/core-linux-arm-gnueabihf": "1.15.6",
+        "@swc/core-linux-arm64-gnu": "1.15.6",
+        "@swc/core-linux-arm64-musl": "1.15.6",
+        "@swc/core-linux-x64-gnu": "1.15.6",
+        "@swc/core-linux-x64-musl": "1.15.6",
+        "@swc/core-win32-arm64-msvc": "1.15.6",
+        "@swc/core-win32-ia32-msvc": "1.15.6",
+        "@swc/core-win32-x64-msvc": "1.15.6"
       },
       "peerDependencies": {
         "@swc/helpers": ">=0.5.17"
@@ -1322,9 +1322,9 @@
       }
     },
     "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.5.tgz",
-      "integrity": "sha512-RvdpUcXrIz12yONzOdQrJbEnq23cOc2IHOU1eB8kPxPNNInlm4YTzZEA3zf3PusNpZZLxwArPVLCg0QsFQoTYw==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.6.tgz",
+      "integrity": "sha512-8pv6W49H70/yxNAC0k+W/Ko3nJW2Za706C1a8q6XhT4JtMLyaYqb+KeoBfIOR8F7qNhMdMa7wdOY5DLPk5cPSg==",
       "cpu": [
         "arm64"
       ],
@@ -1339,9 +1339,9 @@
       }
     },
     "node_modules/@swc/core-darwin-x64": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.5.tgz",
-      "integrity": "sha512-ufJnz3UAff/8G5OfqZZc5cTQfGtXyXVLTB8TGT0xjkvEbfFg8jZUMDBnZT/Cn0k214JhMjiLCNl0A8aY/OKsYQ==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.6.tgz",
+      "integrity": "sha512-v4mDTwA+UdYEHKvzefc3VX/4a7QrRnAFZzNwL33PcLNUJhWbBg6ptcQpBDz/xWOjU6m+pC0IQfzcs16rkAFCHg==",
       "cpu": [
         "x64"
       ],
@@ -1356,9 +1356,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.5.tgz",
-      "integrity": "sha512-Yqu92wIT0FZKLDWes+69kBykX97hc8KmnyFwNZGXJlbKUGIE0hAIhbuBbcY64FGSwey4aDWsZ7Ojk89KUu9Kzw==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.6.tgz",
+      "integrity": "sha512-OT8rIl24/mu4bgDPJT6FVcW+WF3ep9VTau69FspjeycNIa0U0est1ooHxxJyTcO8Qdv0Jy11oXHwtxslZ6KXcw==",
       "cpu": [
         "arm"
       ],
@@ -1373,9 +1373,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.5.tgz",
-      "integrity": "sha512-3gR3b5V1abe/K1GpD0vVyZgqgV+ykuB5QNecDYzVroX4QuN+amCzQaNSsVM8Aj6DbShQCBTh3hGHd2f3vZ8gCw==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.6.tgz",
+      "integrity": "sha512-RKdeG9HBecClhtNJpGyZCYwvGrjzxDzQxGaVOQa44DbNSlVgupj6LnqNSt0RCTy8HEjra1WTD8dCJ9AR++dznQ==",
       "cpu": [
         "arm64"
       ],
@@ -1390,9 +1390,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.5.tgz",
-      "integrity": "sha512-Of+wmVh5h47tTpN9ghHVjfL0CJrgn99XmaJjmzWFW7agPdVY6gTDgkk6zQ6q4hcDQ7hXb0BGw6YFpuanBzNPow==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.6.tgz",
+      "integrity": "sha512-+llo+x7fRyyYd5qGfeYyHgDoZy7M9jKQKmYjTKTJ1BMoydeBoujUWtw+L3tOHyrzKBWOdmVhwdyK+Rx8DeOaGQ==",
       "cpu": [
         "arm64"
       ],
@@ -1407,9 +1407,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.5.tgz",
-      "integrity": "sha512-98kuPS0lZVgjmc/2uTm39r1/OfwKM0PM13ZllOAWi5avJVjRd/j1xA9rKeUzHDWt+ocH9mTCQsAT1jjKSq45bg==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.6.tgz",
+      "integrity": "sha512-1Ufezv5CtJOZaIzYUVMWPORNXgY1MuBrU6LPIeACkdpIaY2wiyfvTiMF57yZ3/c6RQQAY5ZmgV44wCe4dhUFew==",
       "cpu": [
         "x64"
       ],
@@ -1424,9 +1424,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.5.tgz",
-      "integrity": "sha512-Rk+OtNQP3W/dZExL74LlaakXAQn6/vbrgatmjFqJPO4RZkq+nLo5g7eDUVjyojuERh7R2yhqNvZ/ZZQe8JQqqA==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.6.tgz",
+      "integrity": "sha512-hKhR3mAvLvp1bmSrM68DyW+p8vKoFospxtffCTdC0fUR+Y6GEmSMTh+KcQ5vcGptnS2VB6QhZx3oLdzoBs0R6g==",
       "cpu": [
         "x64"
       ],
@@ -1441,9 +1441,9 @@
       }
     },
     "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.5.tgz",
-      "integrity": "sha512-e3RTdJ769+PrN25iCAlxmsljEVu6iIWS7sE21zmlSiipftBQvSAOWuCDv2A8cH9lm5pSbZtwk8AUpIYCNsj2oQ==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.6.tgz",
+      "integrity": "sha512-s3AMvEOxS+H4l2+bEYwKkfDBf34u1/i+t7OgflFCaZ9wSDA3f693bptPO3m1/DrMTq1iEztEV2MPbjMmQqOmBw==",
       "cpu": [
         "arm64"
       ],
@@ -1458,9 +1458,9 @@
       }
     },
     "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.5.tgz",
-      "integrity": "sha512-NmOdl6kyAw6zMz36zCdopTgaK2tcLA53NhUsTRopBc/796Fp87XdsslRHglybQ1HyXIGOQOKv2Y14IUbeci4BA==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.6.tgz",
+      "integrity": "sha512-oD9REGtkA/kU+d9xBa0jddrn4BEIfWA7Jx+O+KD1Dhvgd23aYVWwR98kote6DbC/5nAbt201JnW73SkYHBm4pQ==",
       "cpu": [
         "ia32"
       ],
@@ -1475,9 +1475,9 @@
       }
     },
     "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.5.tgz",
-      "integrity": "sha512-EPXJRf0A8eOi8woXf/qgVIWRl9yeSl0oN1ykGZNCGI7oElsfxUobJFmpJFJoVqKFfd1l0c+GPmWsN2xavTFkNw==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.6.tgz",
+      "integrity": "sha512-oJ17Ouy1BkoUM5R8HJF8nX8IbiDror8tjW9x/PUoUVmtxxVb42vpXrS6xGDpH0mXx8K1wVVS6DOgH83uwKEBUQ==",
       "cpu": [
         "x64"
       ],
@@ -1909,9 +1909,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.9.8",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.8.tgz",
-      "integrity": "sha512-Y1fOuNDowLfgKOypdc9SPABfoWXuZHBOyCS4cD52IeZBhr4Md6CLLs6atcxVrzRmQ06E7hSlm5bHHApPKR/byA==",
+      "version": "2.9.9",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.9.tgz",
+      "integrity": "sha512-V8fbOCSeOFvlDj7LLChUcqbZrdKD9RU/VR260piF1790vT0mfLSwGc/Qzxv3IqiTukOpNtItePa0HBpMAj7MDg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {


### PR DESCRIPTION
## 概要
- WSL 上での Node.js / npm 環境に合わせて、`frontend/package-lock.json` を再生成

## 背景
- これまで Windows 側の Node.js / npm を使って `frontend` の依存関係をインストールしていたため、
  `package-lock.json` が Windows 側の環境で生成された状態になっていた
- WSL 上に `nvm` で Node.js v22 を導入し、今後は WSL を開発環境として統一するため、
  `npm install` を WSL 上で実行し直した結果、`package-lock.json` に差分が発生した

## 変更内容
- `frontend/package-lock.json`
  - 依存パッケージの内容自体は変えず、WSL 上の Node.js / npm でロックファイルを再生成
  - これにより、今後 `npm install` を実行した際の挙動が WSL 環境と整合するよう修正

## 動作確認
- WSL (Ubuntu) 上で以下を実行
  - `cd frontend`
  - `npm install`
  - `npm run dev`
- ブラウザで `http://localhost:5173/` にアクセスし、Vite の初期画面が表示されることを確認

## 影響範囲
- フロントエンドの依存関係インストール時のロックファイルのみ
- アプリのビルド内容やランタイムの挙動への影響はなし（依存バージョンは `package.json` に準拠）

## 関連Issue
- なし
