### PR TITLE
Feat/51 typescript type definitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+frontend/node_modules/
+frontend/dist/

--- a/app/controllers/v1/smoking_areas_controller.rb
+++ b/app/controllers/v1/smoking_areas_controller.rb
@@ -1,25 +1,25 @@
 class V1::SmokingAreasController < ApplicationController
   def index
-    smoking_areas = SmokingArea.order(:id).includes(:tobacco_types)
+    smoking_areas = SmokingArea.all
 
-    # たばこ種別フィルタ（tobacco_type_id が指定された場合）
-    if params[:tobacco_type_id].present?
+    if params[:electronic_only].present?
+      paper_id      = TobaccoType.find_by!(name: "紙タバコ").id
+      electronic_id = TobaccoType.find_by!(name: "電子タバコ").id
+
       smoking_areas = smoking_areas
         .joins(:tobacco_types)
-        .where(tobacco_types: { id: params[:tobacco_type_id] })
+        .where(tobacco_types: { id: electronic_id })
+        .where.not(id: SmokingArea.joins(:tobacco_types).where(tobacco_types: { id: paper_id }))
+    
+    elsif params[:tobacco_type_id].present?
+      filtered_ids = SmokingArea
+        .joins(:tobacco_types)
+        .where(tobacco_types: { id: params[:tobacco_type_id]})
+        .select(:id)
+      smoking_areas = smoking_areas.where(id: filtered_ids)
     end
 
-    # 名前検索（query が指定されていて、実質的な文字がある場合）
-    if params[:query].present?
-      query = params[:query].squish  # 前後の空白 + 連続空白 + 全角スペースも正規化
-      if query != ""
-        smoking_areas = smoking_areas.where("smoking_areas.name ILIKE ?", "%#{query}%")
-      end
-    end
-
-    # join で重複する可能性があるので distinct、
-    # かつ既存仕様どおり id 昇順で返す
-    smoking_areas = smoking_areas.distinct.order(:id)
+    smoking_areas = smoking_areas.includes(:tobacco_types).distinct.order(:id)
 
     render json: (smoking_areas.map do |smoking_area|
       {

--- a/app/models/smoking_area.rb
+++ b/app/models/smoking_area.rb
@@ -17,4 +17,25 @@ class SmokingArea < ApplicationRecord
                              less_than_or_equal_to: 180 }
 
   validates :is_indoor, inclusion: {in: [true, false]}, allow_nil: true
+
+  before_validation :normalize_tobacco_types 
+  validate :must_have_tobacco_types
+
+  private
+
+  def normalize_tobacco_types
+    paper      = TobaccoType.find_by(name: "紙タバコ")
+    electronic = TobaccoType.find_by(name: "電子タバコ")
+    return unless paper && electronic
+
+    if tobacco_type_ids.blank?
+      self.tobacco_type_ids = [paper.id, electronic.id]
+    elsif tobacco_type_ids.include?(paper.id) && !tobacco_type_ids.include?(electronic.id)
+      self.tobacco_type_ids = (tobacco_type_ids + [electronic.id]).uniq
+    end
+  end
+
+  def must_have_tobacco_types
+    errors.add(:tobacco_types, "は1つ以上必要です") if tobacco_types.blank?
+  end
 end

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+.env.local
+.env.*.local

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,35 +1,37 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import { useState, useEffect } from "react";
+import { useSmokingAreas } from "./features/smokingAreas/hooks/useSmokingAreas";
+import { useSmokingAreaDetail } from "./features/smokingAreas/hooks/useSmokingAreaDetail";
+import { useTobaccoTypes } from "./features/smokingAreas/hooks/useTobaccoTypes";
+import { SmokingAreasMap } from "./SmokingAreasMap";
+import type { SmokingAreaSearchParams } from "./features/smokingAreas/types"
 
-function App() {
-  const [count, setCount] = useState(0)
+export default function App() {
+  const [ params, setParams ] = useState<SmokingAreaSearchParams>({});
+  const [ selectedId, setSelectedId ] = useState<number | null>(null);
+
+  const { data, isLoading, error, refetch } = useSmokingAreas(params);
+
+  const { data: detail } = useSmokingAreaDetail(selectedId);
+  const { data: tobaccoTypes } = useTobaccoTypes();
+
+  useEffect(() => {
+    if (selectedId === null) return;
+    const found = data.find((area) => area.id === selectedId);
+    if (!found) setSelectedId(null);
+  }, [data]);
 
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
-  )
+    <SmokingAreasMap
+      smokingAreas={data}
+      selectedId={selectedId}
+      setSelectedId={setSelectedId}
+      detail={detail}
+      tobaccoTypes={tobaccoTypes ?? []}
+      params={params}
+      setParams={setParams}
+      isLoading={isLoading}
+      error={error}
+      refetch={refetch}
+    />
+  );
 }
-
-export default App

--- a/frontend/src/SmokingAreasMap.tsx
+++ b/frontend/src/SmokingAreasMap.tsx
@@ -1,0 +1,69 @@
+import {  APIProvider, Map, AdvancedMarker, InfoWindow, useAdvancedMarkerRef, MapControl, ControlPosition } from "@vis.gl/react-google-maps";
+import { TobaccoTypeFilter }  from "./TobaccoTypeFilter"
+import type { SmokingAreaDisplay, SmokingAreaDetail, TobaccoType, SmokingAreaSearchParams } from "./features/smokingAreas/types";
+
+type SmokingAreasMapProps = { 
+  smokingAreas: SmokingAreaDisplay[];
+  isLoading: boolean;
+  error: Error | null;
+  selectedId: number | null;
+  setSelectedId: (id: number | null) => void;
+  detail: SmokingAreaDetail | null;
+  tobaccoTypes: TobaccoType[];
+  params: SmokingAreaSearchParams
+  setParams: (params: SmokingAreaSearchParams) => void;
+  refetch: () => Promise<void>;
+};
+
+export const SmokingAreasMap = ({ smokingAreas, selectedId, setSelectedId, detail, tobaccoTypes, params, setParams, isLoading, error, refetch }: SmokingAreasMapProps) => {
+  const apiKey = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
+  const mapId = import.meta.env.VITE_GOOGLE_MAPS_MAP_ID;
+
+  const [markerRef, marker] = useAdvancedMarkerRef();
+  const selectedSmokingArea = selectedId === null ? null : smokingAreas.find((smokingArea) => smokingArea.id === selectedId) ?? null;
+  const selectedDetail = selectedId !== null && detail?.id === selectedId ? detail : null;
+
+  const selectedTobaccoTypeIds = selectedSmokingArea?.tobaccoTypeIds ?? []
+  const selectedTobaccoTypes = tobaccoTypes.filter((tobaccoType) => selectedTobaccoTypeIds.includes(tobaccoType.id))
+                               .sort((a, b) => a.displayOrder - b.displayOrder)
+                               .map((tobaccoType) => tobaccoType.name)
+                               .join(", ");
+
+  const center = { lat: 35.690921, lng: 139.700258 };
+
+  return (
+    <div className="map-container">
+      {isLoading && <div className="loading-overlay">Loading...</div>}
+      {error && 
+        <div className="error-overlay">
+          <p>データの取得に失敗しました</p>
+          <button onClick={refetch}>再取得</button>
+        </div>}
+      <APIProvider apiKey={apiKey} libraries={['marker']}>
+        <Map defaultCenter={center} defaultZoom={16} mapId={mapId} fullscreenControl={true}
+        disableDefaultUI={true} zoomControl={true} clickableIcons={false} keyboardShortcuts={false}>
+        {selectedSmokingArea && marker && (
+          <InfoWindow anchor={marker} onCloseClick={() => setSelectedId(null)}>
+            <div><strong>{selectedSmokingArea.name}</strong></div>
+            <div>対応：{selectedTobaccoTypes}</div>
+            <div>詳細：{selectedDetail?.detail}</div>
+          </InfoWindow>
+        )}
+          <MapControl position={ControlPosition.TOP_LEFT}>
+            <TobaccoTypeFilter params={params} setParams={setParams} />
+          </MapControl>
+          {smokingAreas.map((smokingArea) => {
+            const isSelected = selectedId === smokingArea.id;
+            return <AdvancedMarker 
+            key={smokingArea.id} 
+            position={{ lat: smokingArea.latitude, lng: smokingArea.longitude}}
+            onClick={() => setSelectedId(isSelected ? null : smokingArea.id)} 
+            ref={isSelected ? markerRef : undefined}>
+              <div className={isSelected ? "marker-dot marker-dot--selected" : "marker-dot"}></div>
+            </AdvancedMarker>
+          })}
+        </Map>
+      </APIProvider>
+    </div>
+  )
+};

--- a/frontend/src/TobaccoTypeFilter.tsx
+++ b/frontend/src/TobaccoTypeFilter.tsx
@@ -1,0 +1,34 @@
+import type { SmokingAreaSearchParams } from "./features/smokingAreas/types";
+
+type TobaccoTypeProps = {
+  params: SmokingAreaSearchParams
+  setParams: (params: SmokingAreaSearchParams) => void
+};
+
+const FILTER_OPTIONS = [
+  {key: "paper", label: "紙タバコ", tobaccoTypeId: 1},
+  {key: "electronic_only", label: "電子タバコのみ", electronicOnly: true}
+] as const;
+
+export const TobaccoTypeFilter = ({ params, setParams }: TobaccoTypeProps) => {
+
+  return (
+      <>
+      {FILTER_OPTIONS.map((option) => {
+          const isActive = option.key === "paper" ? params.tobaccoTypeId === option.tobaccoTypeId : params.electronicOnly === true;
+          return <button type="button" key={option.key} 
+            onClick={() => {
+              if (isActive) {
+                setParams({});
+              } else if (option.key === "paper") {
+                setParams({tobaccoTypeId: option.tobaccoTypeId});
+              } else {
+                setParams({electronicOnly: true});
+              };
+            }}
+            aria-pressed={isActive} className={isActive ? "button button--active" : "button"}>
+          {option.label}</button>
+        })}
+      </>
+  );
+};

--- a/frontend/src/api/httpClient.ts
+++ b/frontend/src/api/httpClient.ts
@@ -1,0 +1,41 @@
+export type HttpMethod = "GET";
+
+export type QueryParams = Record<string, string | number | undefined>
+
+export type HttpRequestOptions = {
+  method?: HttpMethod;
+  query?: QueryParams;
+};
+
+const API_BASE_URL = "http://localhost:5173";
+
+const buildUrl = (path: string, query?: QueryParams):string => {
+  const urlObj = new URL(path, API_BASE_URL);
+
+  if (query) {
+    Object.entries(query).forEach(([key, value]) => {
+      if (value === undefined) return;
+      urlObj.searchParams.set(key, String(value));
+    })
+  };
+
+  return urlObj.toString();
+};
+
+export const fetchJson = async <T>(
+  path: string,
+  options: HttpRequestOptions = {},
+): Promise<T> => {
+    const requestUrl = buildUrl(path, options.query);
+
+    const response = await fetch(requestUrl, {
+        method: options.method ?? "GET",
+    });
+
+    if (!response.ok) {
+        throw new Error(`HTTP error: ${response.status}`);
+    }
+
+    const data = (await response.json()) as T;
+    return data;
+};

--- a/frontend/src/api/smokingAreas/client.ts
+++ b/frontend/src/api/smokingAreas/client.ts
@@ -1,0 +1,30 @@
+import { fetchJson } from "../httpClient";
+import { toSmokingAreaDisplay, toSmokingAreaDetail } from "./mapper";
+import type { ApiSmokingAreaIndexItem, ApiSmokingAreaShow } from "./types";
+import type { SmokingAreaDisplay, SmokingAreaDetail, SmokingAreaSearchParams } from "../../features/smokingAreas/types";
+import type { QueryParams } from "../httpClient";
+
+
+const buildSmokingAreasQuery = (params?: SmokingAreaSearchParams): QueryParams | undefined => {
+    if (!params) return undefined;
+
+    const { tobaccoTypeId, query } = params;
+
+    if (tobaccoTypeId === undefined && query === undefined) return undefined;
+
+    return {
+        tobacco_type_id: tobaccoTypeId,
+        query,
+    };
+};
+
+export const fetchSmokingAreas = async (params?: SmokingAreaSearchParams): Promise<SmokingAreaDisplay[]> => {
+    const query = buildSmokingAreasQuery(params);
+    const apiItems = await fetchJson<ApiSmokingAreaIndexItem[]>("/v1/smoking_areas", { query });
+    return apiItems.map(toSmokingAreaDisplay);
+};
+
+export const fetchSmokingAreaDetail = async (id: number): Promise<SmokingAreaDetail> => {
+    const api = await fetchJson<ApiSmokingAreaShow>(`/v1/smoking_areas/${id}`);
+    return toSmokingAreaDetail(api);
+};

--- a/frontend/src/api/smokingAreas/client.ts
+++ b/frontend/src/api/smokingAreas/client.ts
@@ -8,13 +8,13 @@ import type { QueryParams } from "../httpClient";
 const buildSmokingAreasQuery = (params?: SmokingAreaSearchParams): QueryParams | undefined => {
     if (!params) return undefined;
 
-    const { tobaccoTypeId, query } = params;
+    const { tobaccoTypeId, electronicOnly } = params;
 
-    if (tobaccoTypeId === undefined && query === undefined) return undefined;
+    if (tobaccoTypeId === undefined && electronicOnly === undefined) return undefined;
 
     return {
         tobacco_type_id: tobaccoTypeId,
-        query,
+        electronic_only: electronicOnly ? "true" : undefined,
     };
 };
 

--- a/frontend/src/api/smokingAreas/mapper.ts
+++ b/frontend/src/api/smokingAreas/mapper.ts
@@ -1,0 +1,29 @@
+import type { ApiSmokingAreaIndexItem, ApiSmokingAreaShow } from "./types";
+import type { SmokingAreaDisplay, SmokingAreaDetail } from "../../features/smokingAreas/types";
+
+export const toSmokingAreaDisplay = (api: ApiSmokingAreaIndexItem): SmokingAreaDisplay => {
+    return {
+        id: api.id,
+        name: api.name,
+        latitude: Number(api.latitude),
+        longitude: Number(api.longitude),
+        tobaccoTypeIds: api.tobacco_type_ids
+    };
+};
+
+export const toSmokingAreaDetail = (api: ApiSmokingAreaShow): SmokingAreaDetail => {
+    return {
+        id: api.id,
+        name: api.name,
+        latitude: Number(api.latitude),
+        longitude: Number(api.longitude),
+        isIndoor: api.is_indoor,
+        detail: api.detail,
+        address: api.address,
+        tobaccoTypes: api.tobacco_types.map((tobacco_type) => ({
+            id: tobacco_type.id,
+            name: tobacco_type.name,
+            icon: tobacco_type.icon
+        })),
+    };
+};

--- a/frontend/src/api/smokingAreas/types.ts
+++ b/frontend/src/api/smokingAreas/types.ts
@@ -1,0 +1,24 @@
+export type ApiSmokingAreaIndexItem = {
+    id: number;
+    name: string;
+    latitude: string;
+    longitude: string;
+    tobacco_type_ids: number[];
+};
+
+export type ApiSmokingAreaShowTobaccoType = {
+    id: number;
+    name: string;
+    icon: string;
+};
+
+export type ApiSmokingAreaShow = {
+    id: number;
+    name: string;
+    latitude: string;
+    longitude: string;
+    is_indoor: boolean | null;
+    detail: string | null;
+    address: string | null;
+    tobacco_types: ApiSmokingAreaShowTobaccoType[];
+};

--- a/frontend/src/api/tobaccoTypes/client.ts
+++ b/frontend/src/api/tobaccoTypes/client.ts
@@ -1,0 +1,9 @@
+import { fetchJson } from "../httpClient";
+import { toTobaccoType } from "./mapper";
+import type { ApiTobaccoType } from "./types";
+import type { TobaccoType } from "../../features/smokingAreas/types";
+
+export const fetchTobaccoTypes = async (): Promise<TobaccoType[]> => {
+    const apiTobaccoTypes = await fetchJson<ApiTobaccoType[]>("/v1/tobacco_types");
+    return apiTobaccoTypes.map(toTobaccoType);
+};

--- a/frontend/src/api/tobaccoTypes/mapper.ts
+++ b/frontend/src/api/tobaccoTypes/mapper.ts
@@ -1,0 +1,11 @@
+import type { TobaccoType } from "../../features/smokingAreas/types";
+import type { ApiTobaccoType } from "./types";
+
+export const toTobaccoType = (api: ApiTobaccoType): TobaccoType => {
+    return {
+        id: api.id,
+        name: api.name,
+        icon: api.icon,
+        displayOrder: api.display_order
+    };
+};

--- a/frontend/src/api/tobaccoTypes/types.ts
+++ b/frontend/src/api/tobaccoTypes/types.ts
@@ -1,0 +1,6 @@
+export type ApiTobaccoType = {
+    id: number;
+    name: string;
+    icon: string;
+    display_order: number;
+};

--- a/frontend/src/features/smokingAreas/hooks/toError.ts
+++ b/frontend/src/features/smokingAreas/hooks/toError.ts
@@ -1,0 +1,17 @@
+export const toError = (e: unknown): Error => {
+    if (e instanceof Error) {
+        return e;
+    } else if (e == null) {
+        return new Error("Unknown error");
+    } else if (typeof e === "string" || typeof e === "number" || typeof e === "boolean") {
+        return new Error(String(e));
+    } else if (typeof e === 'object') {
+        const maybeMessageObject = e as { message?: unknown };
+        const message = maybeMessageObject.message;
+        if (typeof message === "string") {
+            return new Error(message);
+        };
+    };
+    
+    return new Error("Unknown error");
+};

--- a/frontend/src/features/smokingAreas/hooks/useSmokingAreaDetail.ts
+++ b/frontend/src/features/smokingAreas/hooks/useSmokingAreaDetail.ts
@@ -1,0 +1,43 @@
+import { useEffect, useState } from "react";
+import type { SmokingAreaDetail } from "../types";
+import { fetchSmokingAreaDetail } from "../../../api/smokingAreas/client";
+import { toError } from "./toError";
+
+type UseSmokingAreaDetailResult = {
+    data: SmokingAreaDetail | null;
+    isLoading: boolean;
+    error: Error | null;
+    refetch: () => Promise<void>;
+};
+
+export const useSmokingAreaDetail = (id: number | null): UseSmokingAreaDetailResult => {
+    const [data, setData] = useState<SmokingAreaDetail | null>(null);
+    const [isLoading, setIsLoading] = useState<boolean>(true);
+    const [error, setError] = useState<Error | null>(null);
+
+    const refetch = async () => {
+        if (id === null) {
+            setData(null);
+            setError(null);
+            setIsLoading(false);
+            return;
+        };
+        
+        setIsLoading(true);
+        setError(null);
+        try {
+            const smokingArea = await fetchSmokingAreaDetail(id);
+            setData(smokingArea);
+        } catch (e) {
+            setError(toError(e));
+        } finally {
+            setIsLoading(false);
+        };
+    };
+
+    useEffect(() => {
+        refetch();
+    }, [id]);
+
+    return { data, isLoading, error, refetch };
+};

--- a/frontend/src/features/smokingAreas/hooks/useSmokingAreas.ts
+++ b/frontend/src/features/smokingAreas/hooks/useSmokingAreas.ts
@@ -1,0 +1,36 @@
+import type { SmokingAreaDisplay, SmokingAreaSearchParams } from "../types";
+import { fetchSmokingAreas } from "../../../api/smokingAreas/client";
+import { useEffect, useState } from "react";
+import { toError } from "./toError";
+
+type UseSmokingAreasResult = {
+    data: SmokingAreaDisplay[];
+    isLoading: boolean;
+    error: Error | null;
+    refetch: () => Promise<void>;
+};
+
+export const useSmokingAreas = (params?: SmokingAreaSearchParams): UseSmokingAreasResult => {
+    const [data, setData] = useState<SmokingAreaDisplay[]>([]);
+    const [isLoading, setIsLoading] = useState<boolean>(true);
+    const [error, setError] = useState<Error | null>(null);
+
+    const refetch = async () => {
+        setIsLoading(true);
+        setError(null);
+        try {
+            const smokingAreas = await fetchSmokingAreas(params);
+            setData(smokingAreas);
+        } catch (e) {
+            setError(toError(e));
+        } finally {
+            setIsLoading(false);
+        };
+    };
+
+    useEffect(() => {
+        refetch();
+    }, [params?.tobaccoTypeId, params?.query]);
+
+    return { data, isLoading, error, refetch };
+};

--- a/frontend/src/features/smokingAreas/hooks/useSmokingAreas.ts
+++ b/frontend/src/features/smokingAreas/hooks/useSmokingAreas.ts
@@ -30,7 +30,7 @@ export const useSmokingAreas = (params?: SmokingAreaSearchParams): UseSmokingAre
 
     useEffect(() => {
         refetch();
-    }, [params?.tobaccoTypeId, params?.query]);
+    }, [params?.tobaccoTypeId, params?.electronicOnly]);
 
     return { data, isLoading, error, refetch };
 };

--- a/frontend/src/features/smokingAreas/hooks/useTobaccoTypes.ts
+++ b/frontend/src/features/smokingAreas/hooks/useTobaccoTypes.ts
@@ -1,0 +1,36 @@
+import type { TobaccoType } from "../../../features/smokingAreas/types";
+import { useState, useEffect } from "react";
+import { fetchTobaccoTypes } from "../../../api/tobaccoTypes/client";
+import { toError } from "./toError";
+
+type UseTobaccoTypesResult = {
+  data: TobaccoType[];
+  isLoading: boolean;
+  error: Error | null;
+  refetch: () => Promise<void>;
+};
+
+export const useTobaccoTypes = (): UseTobaccoTypesResult => {
+    const [data, setData] = useState<TobaccoType[]>([]);
+    const [isLoading, setIsLoading] = useState<boolean>(true);
+    const [error, setError] = useState<Error | null>(null);
+
+    const refetch = async () => {
+        setIsLoading(true);
+        setError(null);
+        try {
+            const tobaccoTypes = await fetchTobaccoTypes();
+            setData(tobaccoTypes);
+        } catch (e) {
+            setError(toError(e));
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        refetch();
+    }, [])
+
+    return { data, isLoading, error, refetch };
+};

--- a/frontend/src/features/smokingAreas/types.ts
+++ b/frontend/src/features/smokingAreas/types.ts
@@ -1,31 +1,31 @@
 export type SmokingAreaDisplay = {
-    id: number;
-    name: string;
-    latitude: number;
-    longitude: number;
-    tobaccoTypeIds: number[];
+  id: number;
+  name: string;
+  latitude: number;
+  longitude: number;
+  tobaccoTypeIds: number[];
 };
 
 export type SmokingAreaDetailTobaccoType = {
-    id: number;
-    name: string;
-    icon: string
+  id: number;
+  name: string;
+  icon: string;
 };
 
 export type SmokingAreaDetail = {
-    id: number;
-    name: string;
-    latitude: number;
-    longitude: number;
-    isIndoor: boolean | null;
-    detail: string | null;
-    address: string | null;
-    tobaccoTypes: SmokingAreaDetailTobaccoType[];
+  id: number;
+  name: string;
+  latitude: number;
+  longitude: number;
+  isIndoor: boolean | null;
+  detail: string | null;
+  address: string | null;
+  tobaccoTypes: SmokingAreaDetailTobaccoType[];
 };
 
 export type SmokingAreaSearchParams = {
-    tobaccoTypeId?: number;
-    query?: string;
+  tobaccoTypeId?: number;
+  query?: string;electronicOnly?: boolean;
 };
 
 export type TobaccoType = {

--- a/frontend/src/features/smokingAreas/types.ts
+++ b/frontend/src/features/smokingAreas/types.ts
@@ -1,0 +1,36 @@
+export type SmokingAreaDisplay = {
+    id: number;
+    name: string;
+    latitude: number;
+    longitude: number;
+    tobaccoTypeIds: number[];
+};
+
+export type SmokingAreaDetailTobaccoType = {
+    id: number;
+    name: string;
+    icon: string
+};
+
+export type SmokingAreaDetail = {
+    id: number;
+    name: string;
+    latitude: number;
+    longitude: number;
+    isIndoor: boolean | null;
+    detail: string | null;
+    address: string | null;
+    tobaccoTypes: SmokingAreaDetailTobaccoType[];
+};
+
+export type SmokingAreaSearchParams = {
+    tobaccoTypeId?: number;
+    query?: string;
+};
+
+export type TobaccoType = {
+  id: number;
+  name: string;
+  icon: string;
+  displayOrder: number;
+};

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,68 +1,61 @@
-:root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
 }
 
 body {
   margin: 0;
+  padding: 0;
+}
+
+.map-container {
+  position: relative;
+  width: 100%;
+  height: 100vh;
+}
+
+.loading-overlay,
+.error-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.4);
   display: flex;
-  place-items: center;
-  min-width: 320px;
-  min-height: 100vh;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  z-index: 10;
+  color: white;
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
+.marker-dot {
+  width: 16px;
+  height: 16px;
+  background-color: #4A90D9;
+  border: 2px solid #ffffff;
+  border-radius: 50%;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
 }
 
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
+.marker-dot--selected {
+  background-color: #E84343;
+  transform: scale(1.3);
+}
+
+.button {
+  background-color: #ffffff;
+  border: 2px solid #cccccc;
+  border-radius: 20px;
+  padding: 6px 14px;
+  font-size: 13px;
   cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+.button--active {
+  background-color: #1a73e8;
+  border-color: #1a73e8;
+  color: #ffffff;
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,7 +1,14 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react-swc'
 
-// https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/v1': {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+      }
+    }
+  }
 })


### PR DESCRIPTION
## 概要
喫煙所API のTypeScript型定義、APIクライアント、カスタムフック を実装し、フロントエンドから喫煙所データを取得・表示できるようにした

## 背景
- フロントエンドで喫煙所一覧／詳細を型安全に扱い、検索・フィルタ・詳細表示を実装するために、型定義・API クライアント・フックを整備する必要があるため
- JSON のフィールド名（ `tobacco_type_ids` / `tobacco_types` 等）をフロントで扱いやすいキャメルケースにマッピングするため

## 内容
### 型定義・API クライアント
- `frontend/src/api/httpClient.ts` に汎用の HTTP リクエスト処理（ `fetchJson` ）を追加
- `frontend/src/api/smokingAreas/types.ts` に喫煙所API のレスポンス型（ `ApiSmokingAreaIndexItem` / `ApiSmokingAreaShowTobaccoType` / `ApiSmokingAreaShow` ）を定義
- `frontend/src/api/smokingAreas/client.ts` に喫煙所一覧・詳細取得の APIクライアント（ `fetchSmokingAreas` / `fetchSmokingAreaDetail` ）を実装
- `frontend/src/api/smokingAreas/mapper.ts` にAPI レスポンスを表示用型に変換するマッパー関数（ `toSmokingAreaDisplay` / `toSmokingAreaDetail` ）を実装
- `frontend/src/api/tobaccoTypes/types.ts` にたばこ種別API のレスポンス型（ `ApiTobaccoType` ）を定義
- `frontend/src/api/tobaccoTypes/client.ts` にたばこ種別取得のAPIクライアント（ `fetchTobaccoTypes` ）を実装
- `frontend/src/api/tobaccoTypes/mapper.ts` にAPI レスポンスを表示用型に変換するマッパー関数（ `toTobaccoType` ）を実装

### カスタムフック
- `frontend/src/features/smokingAreas/types.ts` にフロントエンド内部で使用する型（ `SmokingAreaDisplay` / `SmokingAreaDetail` / `TobaccoType` / `SmokingAreaSearchParams` ）を定義
- `frontend/src/features/smokingAreas/hooks/useSmokingAreas.ts` に喫煙所一覧取得用フック（検索パラメータに応じた再取得）を実装
- `frontend/src/features/smokingAreas/hooks/useSmokingAreaDetail.ts` に喫煙所詳細取得用フック を実装
- `frontend/src/features/smokingAreas/hooks/useTobaccoTypes.ts` にたばこ種別取得用フック を実装
- `frontend/src/features/smokingAreas/hooks/toError.ts` に汎用エラー変換ユーティリティを実装

### UIコンポーネント
- `frontend/src/SmokingAreasMap.tsx` にGoogle Maps を使用した喫煙所表示コンポーネント、マーカー・詳細情報ウィンドウ、ローディング・エラー表示を実装
- `frontend/src/TobaccoTypeFilter.tsx` にたばこ種別フィルターコンポーネント（「紙タバコ」「電子タバコのみ」のフィルター）を実装
- `frontend/src/App.tsx` を新規実装に置き換え、フック・コンポーネント を統合

### 設定・スタイル
- `frontend/vite.config.ts` に開発時の API プロキシ設定（ `/v1`  を `http://localhost:3000` へ転送）を追加
- `frontend/src/index.css` をマップコンテナ、マーカー、ボタンスタイルに置き換え
- `frontend/.gitignore` に `.env.local` / `.env.*.local` を追加
- `.gitignore` に `frontend/node_modules/` / `frontend/dist/` を追加

### バックエンドAPI仕様変更
- `app/controllers/v1/smoking_areas_controller.rb` で 以下を実装
  - `electronic_only` パラメータによるフィルター機能を追加
  - 既存の `tobacco_type_id` フィルターをリファクタリング
- `app/models/smoking_area.rb` に `normalize_tobacco_types` コールバック / `must_have_tobacco_types` バリデーションを追加

## 動作確認
### フロント
- 開発サーバーを起動して以下をブラウザで確認
  - フィルタボタン UI でたばこ種別を選択して一覧が絞り込まれることを確認
  - 地図上に表示されたマーカーをクリックして `SmokingAreaDetail` の内容が表示されることを確認
  - ネットワーク遅延をシミュレートして、地図上にマーカーの表示/フィルタボタン押下時にローディング表示が表示されることを確認
  - API エラーをシミュレートして、エラー表示が正しく出ることを確認。
  - エラー時の再読み込みボタンを押下し、地図/マーカー/フィルタボタンが表示されることを確認

### バックエンド
`bin/rails console` で以下を実行
``` ruby
# tobacco_type_idsを空で保存したとき
area = SmokingArea.new(name: "テスト", latitude: 35.6, longitude: 139.7)
area.valid? # => true が表示されることを確認
area.tobacco_type_ids # => [1, 2]が表示されることを確認

# 紙タバコのみ指定したとき
paper_id = TobaccoType.find_by(name: "紙タバコ").id
area2 = SmokingArea.new(name: "テスト2", latitude: 35.6, longitude: 139.7, tobacco_type_ids: [paper_id])
area2.valid? # => true が表示されることを確認
area2.tobacco_type_ids # => [1, 2]が表示されることを確認

# 電子タバコのみ指定したとき
electronic_id = TobaccoType.find_by(name: "電子タバコ").id
area3 = SmokingArea.new(name: "テスト3", latitude: 35.6, longitude: 139.7, tobacco_type_ids: [electronic_id])
area3.valid? # => true が表示されることを確認
area3.tobacco_type_ids # => [2]が表示されることを確認
```

`bin/rails s` でサーバを起動し、別ターミナルで以下を実行
```bash
# 全件取得
curl "http://localhost:3000/v1/smoking_areas" | jq . # => 全件取得、喫煙所3件が返ることを確認

# 紙タバコフィルター
curl "http://localhost:3000/v1/smoking_areas?tobacco_type_id=1" | jq . # => 紙タバコを含む喫煙所が返り、各レスポンスのtobacco_type_idsに電子タバコのidも含まれていることを確認

# 電子タバコのみフィルター
curl "http://localhost:3000/v1/smoking_areas?electronic_only=true" | jq . # => seedに電子タバコのみの喫煙所がないため空配列が返ることを確認
```

## 影響範囲
- アプリ機能/API：影響あり（フロントエンド喫煙所マップ表示機能追加、バックエンド API レスポンス仕様変更： `tobacco_type_ids` 追加、`electronic_only` フィルター追加）
- データ移行：不要
- DB変更：なし

## 関連Issue
Closes #51 