### PR TITLE
Chore/66 setup render deployment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ gem "bootsnap", require: false
 # gem "image_processing", "~> 1.2"
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin Ajax possible
-# gem "rack-cors"
+gem "rack-cors"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,6 +156,9 @@ GEM
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.1.16)
+    rack-cors (3.0.0)
+      logger
+      rack (>= 3.0.14)
     rack-session (2.1.1)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
@@ -244,6 +247,7 @@ DEPENDENCIES
   debug
   pg (~> 1.1)
   puma (>= 5.0)
+  rack-cors
   rails (~> 7.1.5, >= 7.1.5.1)
   rspec-rails
   tzinfo-data

--- a/config/database.yml
+++ b/config/database.yml
@@ -15,8 +15,8 @@
 default: &default
   adapter: postgresql
   encoding: unicode
-  username: deku
-  password: toshi3free
+  username: <%= ENV.fetch("DATABASE_USERNAME") { "deku" } %>
+  password: <%= ENV.fetch("DATABASE_PASSWORD") { "" } %>
   host: localhost
   # For details on connection pooling, see Rails configuration guide
   # https://guides.rubyonrails.org/configuring.html#database-pooling

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -81,10 +81,9 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   # Enable DNS rebinding protection and other `Host` header attacks.
-  # config.hosts = [
-  #   "example.com",     # Allow requests from example.com
-  #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
-  # ]
+  config.hosts = [
+    ENV["ALLOWED_HOST"]
+  ]
   # Skip DNS rebinding protection for the default health check endpoint.
-  # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+  config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -5,12 +5,12 @@
 
 # Read more: https://github.com/cyu/rack-cors
 
-# Rails.application.config.middleware.insert_before 0, Rack::Cors do
-#   allow do
-#     origins "example.com"
-#
-#     resource "*",
-#       headers: :any,
-#       methods: [:get, :post, :put, :patch, :delete, :options, :head]
-#   end
-# end
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins ENV["CORS_ALLOWED_ORIGIN"]
+
+    resource "/v1/*",
+      headers: :any,
+      methods: [:get]
+  end
+end

--- a/frontend/src/api/httpClient.ts
+++ b/frontend/src/api/httpClient.ts
@@ -7,7 +7,7 @@ export type HttpRequestOptions = {
   query?: QueryParams;
 };
 
-const API_BASE_URL = "http://localhost:5173";
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || "";
 
 const buildUrl = (path: string, query?: QueryParams): string => {
   const urlObj = new URL(path, API_BASE_URL);


### PR DESCRIPTION
## 概要
- フロントエンド（React）とバックエンド（Rails API + PostgreSQL）をRenderにデプロイし、本番環境でアプリを公開する
- デプロイに必要なCORS設定、環境変数管理を行う

## 背景
- ポートフォリオとして公開できる状態にするため、本番環境へのデプロイが必要
- 本番環境ではフロントエンド（Static Site）とバックエンド（Web Service）を分離構成でデプロイするため、CORS設定や環境変数の本番対応が必要

## 内容
- `Gemfile` / `Gemfile.lock` で `rack-cors` の `gem` を有効化
- `config/database.yml` で `username` / `password` を環境変数に変更（開発環境用のデフォルト値を保持）
- `config/environments/production.rb` で以下の本番環境用の設定を追加
  - `config.hosts` に `ENV["ALLOWED_HOST"]` を指定しホスト認証を有効化
  - ヘルスチェックエンドポイント `/up` をホスト認証から除外
- `config/initializers/cors.rb` でCORS 設定を有効化し、以下の設定を追加
  - オリジンは環境変数 `ENV["CORS_ALLOWED_ORIGIN"]` で指定
  - `/v1/*` のリソースに対して GET メソッドのクロスオリジンリクエストを許可
- `frontend/src/api/httpClient.ts` で `API_BASE_URL` を環境変数化
- Render上で以下を作成し、それぞれに必要な環境設定を追加
  - `PostgreSQL` データベースを作成
  - `Web Service`（Rails）を作成・設定
  - `Static Site`（React）を作成・設定
- Google Cloud Consoleでリファラー制限にRender上のフロントエンドURLを追加

## 影響範囲
- アプリ機能/API：影響あり（CORS により /v1/* への GET リクエストが指定されたオリジンから許可される。本番環境での API アクセスが可能になる）
- データ移行：不要
- DB変更：なし

## 関連Issue
Closes #66 