### PR TITLE
fix: remove unused query field from SmokingAreaSearchParams

### DIFF
--- a/frontend/src/features/smokingAreas/types.ts
+++ b/frontend/src/features/smokingAreas/types.ts
@@ -8,7 +8,6 @@ export type SmokingAreaDisplay = {
 
 export type SmokingAreaSearchParams = {
   tobaccoTypeId?: number;
-  query?: string;
   electronicOnly?: boolean;
 };
 


### PR DESCRIPTION
## 概要
SmokingAreaSearchParams型定義から未使用のqueryフィールドを削除

## 背景
検索機能はMVPスコープから除外済みだが、型定義にqueryフィールドが残っていたため削除

## 内容
`frontend/src/features/smokingAreas/types.ts` の `SmokingAreaSearchParams` から `query?: string` を削除

## 影響範囲
アプリ機能/API：なし
データ移行：不要
DB変更：なし

## 関連Issue
Closes #64 