### PR TITLE
fix: set gestureHandling to greedy for single-finger map operation

### DIFF
--- a/frontend/src/SmokingAreasMap.tsx
+++ b/frontend/src/SmokingAreasMap.tsx
@@ -73,7 +73,7 @@ export const SmokingAreasMap = ({ smokingAreas, selectedId, setSelectedId, tobac
           <button onClick={refetch}>再取得</button>
         </div>}
       <APIProvider apiKey={apiKey} libraries={['marker']}>
-        <Map 
+        <Map
           defaultCenter={defaultCenter}
           defaultZoom={16}
           mapId={mapId}
@@ -84,6 +84,7 @@ export const SmokingAreasMap = ({ smokingAreas, selectedId, setSelectedId, tobac
           keyboardShortcuts={false}
           draggableCursor="default"
           draggingCursor="move"
+          gestureHandling="greedy"
           onClick={() => setSelectedId(null)}>
           <CurrentLocationHandler position={position}/>
           {position && <AdvancedMarker position={position}/>}


### PR DESCRIPTION
## 概要
モバイルでのアプリ操作時に表示される「地図を移動させるには指2本で操作します」の表示及び操作を変更する

## 背景
- 末尾の「す」のみが改行されていて、UI表示の崩れが目立つため
- 地図の操作時に直感的に操作できず、ユーザビリティに影響するため

## 内容
- `SmokingAreasMap` コンポーネントの `Map` プロップスに `gestureHandling="greedy"` を追記する

## 動作確認
- 再デプロイ後にモバイルでアプリを開き、1本指で操作が可能になっていることを確認する

## 影響範囲
- アプリ機能/API：影響あり（モバイルでmapを1本指で操作可能に変更）
- データ移行：不要 
- DB変更：なし

## 関連Issue
Closes #78 