### PR TITLE
Refactor/80 transition to discriminated union

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]
   gem "rspec-rails"
+  gem "dotenv-rails"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,10 @@ GEM
       irb (~> 1.10)
       reline (>= 0.3.8)
     diff-lcs (1.6.2)
+    dotenv (3.2.0)
+    dotenv-rails (3.2.0)
+      dotenv (= 3.2.0)
+      railties (>= 6.1)
     drb (2.2.3)
     erb (5.0.1)
     erubi (1.13.1)
@@ -243,6 +247,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap
   debug
+  dotenv-rails
   pg (~> 1.1)
   puma (>= 5.0)
   rack-cors

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect } from "react";
 import { useSmokingAreas } from "./features/smokingAreas/hooks/useSmokingAreas";
-import { useTobaccoTypes } from "./features/smokingAreas/hooks/useTobaccoTypes";
 import { SmokingAreasMap } from "./SmokingAreasMap";
 import type { SmokingAreaSearchParams } from "./features/smokingAreas/types"
 
@@ -8,28 +7,25 @@ export default function App() {
   const [ params, setParams ] = useState<SmokingAreaSearchParams>({});
   const [ selectedId, setSelectedId ] = useState<number | null>(null);
 
-  const { data, isLoading, error, refetch } = useSmokingAreas(params);
-  const { data: tobaccoTypes } = useTobaccoTypes();
+  const { state, refetch } = useSmokingAreas(params);
 
   useEffect(() => {
     if (selectedId === null) return;
-    const found = data.find((area) => area.id === selectedId);
+    if (state.status !== "success") return;
+    const found = state.data.find((data) => data.id === selectedId);
     if (!found) setSelectedId(null);
-    // dataが変わったとき（タバコ種別フィルターでの変更時）のみ実行し、選択中のidをリセット
+    // stateが変わったとき（タバコ種別フィルターでの変更時）のみ実行し、選択中のidをリセット
     // selectedIdの変化には反応不要のため依存配列から除外（ESLint導入時はdisableコメントを追加）
-  }, [data]);
+  }, [state]);
 
   return (
     <SmokingAreasMap
-      smokingAreas={data}
+      state={state}
       selectedId={selectedId}
       setSelectedId={setSelectedId}
-      tobaccoTypes={tobaccoTypes ?? []}
       params={params}
       setParams={setParams}
-      isLoading={isLoading}
-      error={error}
-      refetch={refetch}
+      refetchSmokingAreas={refetch}
     />
   );
 }

--- a/frontend/src/SmokingAreasMap.tsx
+++ b/frontend/src/SmokingAreasMap.tsx
@@ -1,19 +1,18 @@
 import { APIProvider, Map, AdvancedMarker, MapControl, ControlPosition, useMap } from "@vis.gl/react-google-maps";
 import { TobaccoTypeFilter } from "./TobaccoTypeFilter"
-import type { SmokingAreaDisplay, TobaccoType, SmokingAreaSearchParams } from "./features/smokingAreas/types";
+import { useTobaccoTypes } from "./features/smokingAreas/hooks/useTobaccoTypes";
 import { useEffect, useState } from "react";
 import { LocateFixed } from "lucide-react";
+import type { SmokingAreaDisplay, SmokingAreaSearchParams } from "./features/smokingAreas/types";
+import type { FetchState } from "./types/fetchState";
 
 type SmokingAreasMapProps = {
-  smokingAreas: SmokingAreaDisplay[];
-  isLoading: boolean;
-  error: Error | null;
+  state: FetchState<SmokingAreaDisplay[]>;
   selectedId: number | null;
   setSelectedId: (id: number | null) => void;
-  tobaccoTypes: TobaccoType[];
   params: SmokingAreaSearchParams
   setParams: (params: SmokingAreaSearchParams) => void;
-  refetch: () => Promise<void>;
+  refetchSmokingAreas: () => Promise<void>;
 };
 
 const CurrentLocationHandler = ({ position }: { position: { lat: number, lng: number } | null }) => {
@@ -34,7 +33,7 @@ const CurrentLocationHandler = ({ position }: { position: { lat: number, lng: nu
   );
 };
 
-export const SmokingAreasMap = ({ smokingAreas, selectedId, setSelectedId, tobaccoTypes, params, setParams, isLoading, error, refetch }: SmokingAreasMapProps) => {
+export const SmokingAreasMap = ({ state, selectedId, setSelectedId, params, setParams, refetchSmokingAreas }: SmokingAreasMapProps) => {
   const apiKey = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
   const mapId = import.meta.env.VITE_GOOGLE_MAPS_MAP_ID;
 
@@ -55,7 +54,13 @@ export const SmokingAreasMap = ({ smokingAreas, selectedId, setSelectedId, tobac
     });
   }, []);
 
-  const selectedSmokingArea = selectedId === null ? null : smokingAreas.find((smokingArea) => smokingArea.id === selectedId) ?? null;
+  const getSelectedSmokingArea = (): SmokingAreaDisplay | null => {
+    if (selectedId === null) return null;
+    if (state.status !== "success") return null;
+    return state.data.find((smokingArea) => smokingArea.id === selectedId) ?? null;
+  };
+
+  const selectedSmokingArea = getSelectedSmokingArea();
 
   const selectedTobaccoTypeIds = selectedSmokingArea?.tobaccoTypeIds ?? []
   const selectedTobaccoTypes = tobaccoTypes.filter((tobaccoType) => selectedTobaccoTypeIds.includes(tobaccoType.id))
@@ -68,11 +73,11 @@ export const SmokingAreasMap = ({ smokingAreas, selectedId, setSelectedId, tobac
   return (
     <div className="map-container">
       <TobaccoTypeFilter params={params} setParams={setParams}/>
-      {isLoading && <div className="loading-overlay">Loading...</div>}
-      {error && 
+      {state.status === "loading" && <div className="loading-overlay">Loading...</div>}
+      {state.status === "error" &&
         <div className="error-overlay">
           <p>データの取得に失敗しました</p>
-          <button onClick={refetch}>再取得</button>
+          <button onClick={() => { refetchSmokingAreas(); refetchTobaccoTypes(); }}>再取得</button>
         </div>}
       <APIProvider apiKey={apiKey} libraries={['marker']}>
         <Map
@@ -90,7 +95,7 @@ export const SmokingAreasMap = ({ smokingAreas, selectedId, setSelectedId, tobac
           onClick={() => setSelectedId(null)}>
           <CurrentLocationHandler position={position}/>
           {position && <AdvancedMarker position={position}/>}
-          {smokingAreas.map((smokingArea) => {
+          {state.status === "success" && state.data.map((smokingArea) => {
             const isSelected = selectedId === smokingArea.id;
             return (
               <AdvancedMarker 

--- a/frontend/src/SmokingAreasMap.tsx
+++ b/frontend/src/SmokingAreasMap.tsx
@@ -41,6 +41,8 @@ export const SmokingAreasMap = ({ smokingAreas, selectedId, setSelectedId, tobac
   const [position, setPosition] = useState<{lat: number, lng: number} | null>(null);
   const [isMobile, setIsMobile] = useState(window.innerWidth < 1025);
 
+  const { data: tobaccoTypes, refetch: refetchTobaccoTypes } = useTobaccoTypes();
+
   useEffect(() => {
     const handleResize = () => setIsMobile(window.innerWidth < 1025);
     window.addEventListener("resize", handleResize);

--- a/frontend/src/features/smokingAreas/hooks/useSmokingAreas.ts
+++ b/frontend/src/features/smokingAreas/hooks/useSmokingAreas.ts
@@ -1,30 +1,24 @@
 import type { SmokingAreaDisplay, SmokingAreaSearchParams } from "../types";
+import type { FetchState } from "../../../types/fetchState";
 import { fetchSmokingAreas } from "../../../api/smokingAreas/client";
 import { useEffect, useState } from "react";
 import { toError } from "./toError";
 
 type UseSmokingAreasResult = {
-  data: SmokingAreaDisplay[];
-  isLoading: boolean;
-  error: Error | null;
+  state: FetchState<SmokingAreaDisplay[]>;
   refetch: () => Promise<void>;
 };
 
 export const useSmokingAreas = (params?: SmokingAreaSearchParams): UseSmokingAreasResult => {
-  const [data, setData] = useState<SmokingAreaDisplay[]>([]);
-  const [isLoading, setIsLoading] = useState<boolean>(true);
-  const [error, setError] = useState<Error | null>(null);
+  const [state, setState] = useState<FetchState<SmokingAreaDisplay[]>>({ status: "loading" });
 
   const refetch = async () => {
-    setIsLoading(true);
-    setError(null);
+    setState({ status: "loading" });
     try {
       const smokingAreas = await fetchSmokingAreas(params);
-      setData(smokingAreas);
+      setState({ status: "success", data: smokingAreas });
     } catch (e) {
-      setError(toError(e));
-    } finally {
-      setIsLoading(false);
+      setState({ status: "error", error: toError(e) });
     }
   };
 
@@ -32,5 +26,5 @@ export const useSmokingAreas = (params?: SmokingAreaSearchParams): UseSmokingAre
     refetch();
   }, [params?.tobaccoTypeId, params?.electronicOnly]);
 
-  return { data, isLoading, error, refetch };
+  return { state, refetch };
 };

--- a/frontend/src/features/smokingAreas/hooks/useTobaccoTypes.ts
+++ b/frontend/src/features/smokingAreas/hooks/useTobaccoTypes.ts
@@ -1,36 +1,19 @@
 import type { TobaccoType } from "../../../features/smokingAreas/types";
 import { useState, useEffect } from "react";
 import { fetchTobaccoTypes } from "../../../api/tobaccoTypes/client";
-import { toError } from "./toError";
 
-type UseTobaccoTypesResult = {
-  data: TobaccoType[];
-  isLoading: boolean;
-  error: Error | null;
-  refetch: () => Promise<void>;
-};
-
-export const useTobaccoTypes = (): UseTobaccoTypesResult => {
+export const useTobaccoTypes = () => {
   const [data, setData] = useState<TobaccoType[]>([]);
-  const [isLoading, setIsLoading] = useState<boolean>(true);
-  const [error, setError] = useState<Error | null>(null);
 
-  const refetch = async () => {
-    setIsLoading(true);
-    setError(null);
-    try {
-      const tobaccoTypes = await fetchTobaccoTypes();
-      setData(tobaccoTypes);
-    } catch (e) {
-      setError(toError(e));
-    } finally {
-      setIsLoading(false);
-    }
+  const refetch = () => {
+    fetchTobaccoTypes()
+      .then(setData)
+      .catch(() => {});
   };
 
   useEffect(() => {
     refetch();
   }, []);
 
-  return { data, isLoading, error, refetch };
+  return { data, refetch };
 };

--- a/frontend/src/types/fetchState.ts
+++ b/frontend/src/types/fetchState.ts
@@ -1,0 +1,4 @@
+export type FetchState<T> = 
+  | { status: "loading" }
+  | { status: "success"; data: T }
+  | { status: "error"; error: Error};


### PR DESCRIPTION
## 概要
- カスタムフック useSmokingAreas の状態管理をリファクタリングする
- 現在の3つの個別state( isLoading / error / data )を、FetchState 型による単一 state に集約することで、状態遷移を型安全かつ一貫性のある形で管理する
- カスタムフック useTobaccoTypes のローディング・エラーstateを削除して簡略化
- ローカル環境構築のため dotenv-rails を併せて追加

## 背景
- 現在の実装では複数の state 変数で状態を管理しており、一貫性がなく状態遷移時の矛盾が起こりやすい構造になっている。型安全な状態管理のため、ユニオン型による状態管理パターンで統一管理する
- リファクタリング後の動作確認でバックエンド再起動後に、喫煙所ごとの対応タバコ種別が表示されないバグが発生したため
- rails サーバー起動時に、ローカル環境でのDBのパスワードが未設定になっていることが原因で起動できなかったため、パスワードを環境変数に設定する

## 内容
### バックエンド
- `Gemfile` / `Gemfile.lock` に `dotenv-rails` の `gem` を追加

### フロントエンド
- `frontend/src/types/fetchState.ts` ファイルを新規作成し、判別可能なユニオン型 `FetchState` を定義
- カスタムフック `useTobaccoTypes.ts` 内で以下を変更
  - 型定義 `UseTobaccoTypesResult` と ローディングとエラーの state を削除
  - `refetch` 関数を `try` / `catch` から Promise チェーン（ `catch` 句で何もしない）に書き換え
- カスタムフック `useSmokingAreas.ts` 内で以下を変更
  - `data` / `isLoading` / `error` の三つの型定義と state を `FetchState` を使用した単一の state に統一
  - 更新用関数を `setState` に統一
  - 戻り値を `{ state, refetch }` に変更
- `App.tsx` 内で以下を変更
  - カスタムフック `useTobaccoTypes` の呼び出しを削除
  - `useSmokingAreas` の分割代入を `{ state, refetch }` に変更
  - `useEffect` 内の依存配列と条件判定を state に基づいて更新
  - `SmokingAreasMap` に渡すプロップを変更
- `SmokingAreasMap.tsx` 内で以下を変更
  - カスタムフック `useTobaccoTypes` の呼び出しを `App.tsx` から移動
  - props の型定義 `SmokingAreasMapProps` と `SmokingAreasMap` コンポーネントの props を変更
  - 喫煙所のマーカーがクリックされたときの条件分岐ロジックを `state.status` ベースに変更
  - ローディング・エラー表示の条件判定を `state.status` ベースに変更
  - エラー表示時のボタンクリックハンドラで `useTobaccoTypes` の `refetch` も併せて呼び出すように変更
  - マーカー描画の条件分岐を `state.status === "success"` チェック付きに変更

## 動作確認
- `npx tsc --noEmit` を実行してTypeScriptの型チェックエラーがないことを確認
- `.env.local` にDBパスワードを設定した状態で rails サーバーが起動できることを確認
- アプリケーションを起動して通常時のマップ表示とマーカーが正常に表示されることを確認
- タバコ種別フィルター切り替え時に再フェッチが走り、ローディング → 成功の状態遷移が正常に行われることを確認
- バックエンド停止時にエラー状態になり、再取得ボタンが表示されることを確認
- バックエンドを再起動させ再取得ボタンを押下し、マップ表示とマーカーが正常に表示されることを確認
- `bundle install` を実行してエラーなく実行され、`Gemfile.lock` に `dotenv` / `dotenv-rails` が追加されていることを確認

## 影響範囲
- アプリ機能/API：影響あり
  - 喫煙所データ取得時のローディング・エラー表示の状態管理が FetchState ユニオン型に統一。ユーザー向けの表示ロジックに変更はなし。
  - `dotenv-rails` 追加によるローカル環境構築への影響。他の開発者が root 直下に `.env.local` の作成が必要になる。
- データ移行：不要
- DB変更：なし

## 関連Issue
Closes #80 