### PR TITLE
Feat/82 add zod runtime validation

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,7 +11,8 @@
         "@vis.gl/react-google-maps": "^1.8.1",
         "lucide-react": "^1.7.0",
         "react": "^19.2.0",
-        "react-dom": "^19.2.0"
+        "react-dom": "^19.2.0",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
@@ -3475,10 +3476,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "dev": true,
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,8 @@
     "@vis.gl/react-google-maps": "^1.8.1",
     "lucide-react": "^1.7.0",
     "react": "^19.2.0",
-    "react-dom": "^19.2.0"
+    "react-dom": "^19.2.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/frontend/src/api/httpClient.ts
+++ b/frontend/src/api/httpClient.ts
@@ -22,10 +22,10 @@ const buildUrl = (path: string, query?: QueryParams): string => {
   return urlObj.toString();
 };
 
-export const fetchJson = async <T>(
+export const fetchJson = async (
   path: string,
   options: HttpRequestOptions = {},
-): Promise<T> => {
+): Promise<unknown> => {
   const requestUrl = buildUrl(path, options.query);
 
   const response = await fetch(requestUrl, {
@@ -36,6 +36,5 @@ export const fetchJson = async <T>(
     throw new Error(`HTTP error: ${response.status}`);
   }
 
-  const data = (await response.json()) as T;
-  return data;
+  return response.json();
 };

--- a/frontend/src/api/smokingAreas/client.ts
+++ b/frontend/src/api/smokingAreas/client.ts
@@ -1,6 +1,6 @@
 import { fetchJson } from "../httpClient";
 import { toSmokingAreaDisplay } from "./mapper";
-import type { ApiSmokingAreaIndexItem } from "./types";
+import { ApiSmokingAreaSchema } from "./schema";
 import type { SmokingAreaDisplay, SmokingAreaSearchParams } from "../../features/smokingAreas/types";
 import type { QueryParams } from "../httpClient";
 
@@ -19,6 +19,7 @@ const buildSmokingAreasQuery = (params?: SmokingAreaSearchParams): QueryParams |
 
 export const fetchSmokingAreas = async (params?: SmokingAreaSearchParams): Promise<SmokingAreaDisplay[]> => {
   const query = buildSmokingAreasQuery(params);
-  const apiItems = await fetchJson<ApiSmokingAreaIndexItem[]>("/v1/smoking_areas", { query });
-  return apiItems.map(toSmokingAreaDisplay);
+  const apiItems = await fetchJson("/v1/smoking_areas", { query });
+  const validatedItems = ApiSmokingAreaSchema.array().parse(apiItems);
+  return validatedItems.map(toSmokingAreaDisplay);
 };

--- a/frontend/src/api/smokingAreas/mapper.ts
+++ b/frontend/src/api/smokingAreas/mapper.ts
@@ -1,4 +1,4 @@
-import type { ApiSmokingAreaIndexItem } from "./types";
+import type { ApiSmokingAreaIndexItem } from "./schema";
 import type { SmokingAreaDisplay } from "../../features/smokingAreas/types";
 
 export const toSmokingAreaDisplay = (api: ApiSmokingAreaIndexItem): SmokingAreaDisplay => {

--- a/frontend/src/api/smokingAreas/schema.ts
+++ b/frontend/src/api/smokingAreas/schema.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+export const ApiSmokingAreaSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  latitude: z.string(),
+  longitude: z.string(),
+  tobacco_type_ids: z.array(z.number()),
+});
+
+export type ApiSmokingAreaIndexItem = z.infer<typeof ApiSmokingAreaSchema>;

--- a/frontend/src/api/smokingAreas/types.ts
+++ b/frontend/src/api/smokingAreas/types.ts
@@ -1,7 +1,0 @@
-export type ApiSmokingAreaIndexItem = {
-  id: number;
-  name: string;
-  latitude: string;
-  longitude: string;
-  tobacco_type_ids: number[];
-};

--- a/frontend/src/api/tobaccoTypes/client.ts
+++ b/frontend/src/api/tobaccoTypes/client.ts
@@ -1,9 +1,10 @@
 import { fetchJson } from "../httpClient";
 import { toTobaccoType } from "./mapper";
-import type { ApiTobaccoType } from "./types";
+import { ApiTobaccoTypeSchema } from "./schema";
 import type { TobaccoType } from "../../features/smokingAreas/types";
 
 export const fetchTobaccoTypes = async (): Promise<TobaccoType[]> => {
-  const apiTobaccoTypes = await fetchJson<ApiTobaccoType[]>("/v1/tobacco_types");
-  return apiTobaccoTypes.map(toTobaccoType);
+  const apiTobaccoTypes = await fetchJson("/v1/tobacco_types");
+  const validatedTobaccoTypes = ApiTobaccoTypeSchema.array().parse(apiTobaccoTypes);
+  return validatedTobaccoTypes.map(toTobaccoType);
 };

--- a/frontend/src/api/tobaccoTypes/mapper.ts
+++ b/frontend/src/api/tobaccoTypes/mapper.ts
@@ -1,5 +1,5 @@
 import type { TobaccoType } from "../../features/smokingAreas/types";
-import type { ApiTobaccoType } from "./types";
+import type { ApiTobaccoType } from "./schema";
 
 export const toTobaccoType = (api: ApiTobaccoType): TobaccoType => {
   return {

--- a/frontend/src/api/tobaccoTypes/schema.ts
+++ b/frontend/src/api/tobaccoTypes/schema.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+export const ApiTobaccoTypeSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  icon: z.string(),
+  display_order: z.number(),
+});
+
+export type ApiTobaccoType = z.infer<typeof ApiTobaccoTypeSchema>;

--- a/frontend/src/api/tobaccoTypes/types.ts
+++ b/frontend/src/api/tobaccoTypes/types.ts
@@ -1,6 +1,0 @@
-export type ApiTobaccoType = {
-  id: number;
-  name: string;
-  icon: string;
-  display_order: number;
-};


### PR DESCRIPTION
## 概要
`src/api` 配下に Zod を導入し、API レスポンスのランタイム検証を行うようにした。併せて API レスポンスの型定義を `z.infer` で導出する形に統一し、`types.ts` を削除。

## 背景
変更前の `fetchJson` は戻り値を `as T` でアサートしていたため、Rails 側が型定義と異なるレスポンスを返してもフロント側で検知できなかった。Rails と React+TS で API 契約を共有していないため、フロント側にランタイム検証層を持たないと API 仕様の変更にフロント側が気づけない状態だった。
Zod を導入することで、スキーマ違反を fetch 直後に `ZodError` として捕捉でき、既存のエラーハンドリング（エラー表示・再取得ボタン）に流れるようにした。`ZodError` は `Error` を継承しているため、既存の `toError` を経由してそのまま処理される。

## 内容
- `zod` をインストール
- `src/api/smokingAreas/schema.ts` を新規作成。`ApiSmokingAreaSchema` を定義し、`z.infer` で `ApiSmokingAreaIndexItem` 型を導出
- `src/api/tobaccoTypes/schema.ts` を新規作成。`ApiTobaccoTypeSchema` を定義し、`z.infer` で `ApiTobaccoType` 型を導出
- `src/api/httpClient.ts` の `fetchJson` から型引数 `<T>` を削除、戻り値型を `Promise<unknown>` に変更、`as T` を削除
- `src/api/smokingAreas/client.ts` / `src/api/tobaccoTypes/client.ts` で、`fetchJson` の戻り値を `ApiSmokingAreaSchema.array().parse(...)` / `ApiTobaccoTypeSchema.array().parse(...)` で検証してから `mapper` に渡すよう変更
- `src/api/smokingAreas/mapper.ts` / `src/api/tobaccoTypes/mapper.ts` の import を `./types` から `./schema` に変更
- `src/api/smokingAreas/types.ts` / `src/api/tobaccoTypes/types.ts` を削除

## 動作確認
- `tsc --noEmit` で型エラーが出ないこと
- アプリ起動時にマップ表示、マーカー表示、フィルターボタンが正常に表示されること
- フィルターボタンを押下して喫煙所の絞り込みができること
- Rails サーバーを停止し、ブラウザを更新するとエラー文と再取得ボタンが表示されること
- サーバーを再起動させ、再取得ボタンを押下してアプリの表示が正常であること
- `ApiSmokingAreaSchema` に `__nonexistent_field: z.string()` を一時的に追加し、アプリを起動してエラー文と再取得ボタンが表示されること（Zod のランタイム検証が機能していることの確認）
- 追加した `__nonexistent_field` を削除して元に戻し、アプリを再起動して正常表示に戻ること

## 影響範囲
- アプリ機能/API：影響なし
- データ移行：不要
- DB 変更：なし

## 関連Issue
Closes #82 