### PR TITLE
refactor: fix formatting issues in toError.ts

### DIFF
--- a/frontend/src/features/smokingAreas/hooks/toError.ts
+++ b/frontend/src/features/smokingAreas/hooks/toError.ts
@@ -5,13 +5,13 @@ export const toError = (e: unknown): Error => {
     return new Error("Unknown error");
   } else if (typeof e === "string" || typeof e === "number" || typeof e === "boolean") {
     return new Error(String(e));
-  } else if (typeof e === 'object') {
+  } else if (typeof e === "object") {
     const maybeMessageObject = e as { message?: unknown };
     const message = maybeMessageObject.message;
     if (typeof message === "string") {
       return new Error(message);
-    };
-  };
-  
+    }
+  }
+
   return new Error("Unknown error");
 };


### PR DESCRIPTION
## 概要
- `src/features/smokingAreas/hooks/toError.ts` 内の `if` 文・`else if` 文ブロック末尾に残っている不要なセミコロンを削除し、フォーマットを他ファイルと揃える。
- あわせて、`return` 文前の空行に含まれる行末空白（半角スペース 2 つ）も削除する。
- あわせて、`typeof e === 'object'` のシングルクォートをダブルクォートに修正する（同ファイル・他ファイルとクォートスタイルを統一）。

## 背景
フォーマット統一の対象範囲から漏れていた箇所の補完。

## 内容
- `src/features/smokingAreas/hooks/toError.ts` 内の以下の記述を修正
  - `if` 文ブロック末尾の不要なセミコロンを削除
  - `else if` 文ブロック末尾の不要なセミコロンを削除
  - `return` 文前の空行に含まれる行末空白（半角スペース 2 つ）を削除
  - `typeof e === 'object'` のシングルクォートをダブルクォートに修正

## 動作確認
- `npm run lint` を実行し、本 PR の修正起因のエラー・警告がないことを確認（既存の lint エラー 4 件は本 PR 起因ではないため別 Issue で対応予定。詳細は Issue コメント参照）
- `npm run build` がエラーなしで完了する
- アプリを起動し、API エラー発生時のエラーメッセージ表示が従来通りであることを確認（`toError.ts` の処理経路を通る挙動が変わっていないこと）

## 影響範囲
- アプリ機能/API：影響なし
- データ移行：不要
- DB 変更：なし

## 関連Issue
Closes #84 