### PR TITLE
Fix/85 custom fullscreen control

### DIFF
--- a/frontend/src/SmokingAreasMap.tsx
+++ b/frontend/src/SmokingAreasMap.tsx
@@ -74,7 +74,7 @@ export const SmokingAreasMap = ({ state, selectedId, setSelectedId, params, setP
   const defaultCenter = { lat: 35.6812, lng: 139.7671 };
 
   return (
-    <div className="map-container">
+    <div className="map-container" ref={mapContainerRef}>
       <TobaccoTypeFilter params={params} setParams={setParams}/>
       {state.status === "loading" && <div className="loading-overlay">Loading...</div>}
       {state.status === "error" &&

--- a/frontend/src/SmokingAreasMap.tsx
+++ b/frontend/src/SmokingAreasMap.tsx
@@ -63,6 +63,20 @@ export const SmokingAreasMap = ({ state, selectedId, setSelectedId, params, setP
     return state.data.find((smokingArea) => smokingArea.id === selectedId) ?? null;
   };
 
+  const toggleFullscreen = () => {
+    if (document.fullscreenElement) {
+      document.exitFullscreen();
+    } else {
+      mapContainerRef.current?.requestFullscreen();
+    }
+  };
+
+  useEffect(() => {
+    const handleFullscreenChange = () => setIsFullscreen(Boolean(document.fullscreenElement))
+    document.addEventListener("fullscreenchange", handleFullscreenChange);
+    return () => document.removeEventListener("fullscreenchange", handleFullscreenChange);
+  }, []);
+
   const selectedSmokingArea = getSelectedSmokingArea();
 
   const selectedTobaccoTypeIds = selectedSmokingArea?.tobaccoTypeIds ?? []
@@ -76,6 +90,11 @@ export const SmokingAreasMap = ({ state, selectedId, setSelectedId, params, setP
   return (
     <div className="map-container" ref={mapContainerRef}>
       <TobaccoTypeFilter params={params} setParams={setParams}/>
+      {!isMobile && (
+        <button className="fullscreen-button" onClick={toggleFullscreen}>
+          {isFullscreen ? <Minimize size={20}/> : <Maximize size={20}/>}
+        </button>
+      )}
       {state.status === "loading" && <div className="loading-overlay">Loading...</div>}
       {state.status === "error" &&
         <div className="error-overlay">

--- a/frontend/src/SmokingAreasMap.tsx
+++ b/frontend/src/SmokingAreasMap.tsx
@@ -1,8 +1,8 @@
 import { APIProvider, Map, AdvancedMarker, MapControl, ControlPosition, useMap } from "@vis.gl/react-google-maps";
 import { TobaccoTypeFilter } from "./TobaccoTypeFilter"
 import { useTobaccoTypes } from "./features/smokingAreas/hooks/useTobaccoTypes";
-import { useEffect, useState } from "react";
-import { LocateFixed } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { LocateFixed, Maximize, Minimize } from "lucide-react";
 import type { SmokingAreaDisplay, SmokingAreaSearchParams } from "./features/smokingAreas/types";
 import type { FetchState } from "./types/fetchState";
 
@@ -39,6 +39,9 @@ export const SmokingAreasMap = ({ state, selectedId, setSelectedId, params, setP
 
   const [position, setPosition] = useState<{lat: number, lng: number} | null>(null);
   const [isMobile, setIsMobile] = useState(window.innerWidth < 1025);
+  const [isFullscreen, setIsFullscreen] = useState<boolean>(false);
+
+  const mapContainerRef = useRef<HTMLDivElement>(null);
 
   const { data: tobaccoTypes, refetch: refetchTobaccoTypes } = useTobaccoTypes();
 
@@ -84,7 +87,6 @@ export const SmokingAreasMap = ({ state, selectedId, setSelectedId, params, setP
           defaultCenter={defaultCenter}
           defaultZoom={16}
           mapId={mapId}
-          fullscreenControl={isMobile ? false : true}
           disableDefaultUI={true}
           zoomControl={isMobile ? false : true}
           clickableIcons={false}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -161,6 +161,35 @@ body {
   color: #1B3A5C;
 }
 
+.fullscreen-button {
+  position: absolute;
+  top: 0;
+  right: 0;
+  padding: 10px;
+  width: 40px;
+  height: 40px;
+  background-color: #ffffff;
+  border: none;
+  border-radius: 2px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 10px;
+  color: #666666;
+  z-index: 5;
+}
+
+.fullscreen-button:hover {
+  background-color: #f0f0f0;
+  color: #1B3A5C;
+}
+
+.fullscreen-button:focus {
+  outline: none;
+}
+
 @media (max-width: 767.98px) {
   .button {
     padding: 5px 8px;


### PR DESCRIPTION
## 概要
PC で全画面表示時にタバコ種別フィルターが消える事象を修正した。Google Maps 標準の全画面ボタンを無効化し、.map-container 全体を対象とする自前の全画面ボタンに置き換えた。

## 背景
PC で全画面表示するとタバコ種別フィルターの UI が消える不具合があった。Google Maps 標準のボタンは Map 要素のみを全画面化するため、兄弟配置のフィルターが表示されなくなることが原因だった。フィルターを Map の子要素に移す案は、CSS の制御性とフィルター数の拡張性の観点から不採用とした。

## 内容
- `SmokingAreasMap.tsx` 内で以下を変更
  - `<Map>` の `fullscreenControl` を削除し、標準の全画面ボタンを無効化
  - `useRef` で `.map-container` の DOM 参照を取得
  - `useState` で全画面状態を管理し、`fullscreenchange` イベントで同期
  - 全画面トグルボタンを `.map-container` 内に配置（isMobile 時は非表示）
  - アイコンは `lucide-react` の `Maximize` / `Minimize` を全画面状態に応じて切り替え
- `index.css` で以下を記述
  - 全画面ボタンの見た目を Google Maps 標準に寄せる
  - `.fullscreen-button` のマウスクリック由来のフォーカスリングを `outline: none` で抑制

## 動作確認
- PC で自前実装の全画面ボタンを押すと全画面表示になり、フィルターが表示され操作できることを確認
- 全画面中に Esc キーで通常表示に戻り、ボタンのアイコンが全画面前の状態に戻ることを確認
- 全画面中もマップ操作・マーカー選択・フィルター変更が正常に動作することを確認
- F11 による全画面表示でも従来通り動作することを確認
- モバイル幅（< 1025px）でボタンが非表示になることを確認
- レスポンシブのレイアウトが崩れないことを確認

## 影響範囲
- アプリ機能/API：影響なし
- データ移行：不要
- DB変更：なし

## 関連Issue
Closes #85 