### PR TITLE
refactor: add ESLint disable comments for useEffect in App

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,14 +9,19 @@ export default function App() {
 
   const { state, refetch } = useSmokingAreas(params);
 
+  /* eslint-disable react-hooks/set-state-in-effect, react-hooks/exhaustive-deps */
+  // フィルター後のデータに選択中の喫煙所が含まれなければ選択状態を解除する。
+  // これによりフィルター解除時に選択状態が復活しない。
+  // レンダー内計算だと解除時に selectedId が残り選択状態が復活するため、意図的に Effect 内で更新。
+  // 機能拡張時に TanStack Query を採用し、サーバーサイドでフィルター後の状態を管理する設計に変更するかを検討。
+  // selectedId の変化には反応不要のため依存配列から除外。
   useEffect(() => {
     if (selectedId === null) return;
     if (state.status !== "success") return;
     const found = state.data.find((data) => data.id === selectedId);
     if (!found) setSelectedId(null);
-    // stateが変わったとき（タバコ種別フィルターでの変更時）のみ実行し、選択中のidをリセット
-    // selectedIdの変化には反応不要のため依存配列から除外（ESLint導入時はdisableコメントを追加）
   }, [state]);
+  /* eslint-enable react-hooks/set-state-in-effect, react-hooks/exhaustive-deps */
 
   return (
     <SmokingAreasMap


### PR DESCRIPTION
## 概要
`src/App.tsx` の useEffect で検出される `react-hooks/set-state-in-effect` / `react-hooks/exhaustive-deps` の警告について、現状の挙動を維持する設計判断に基づき、`eslint-disable` / `eslint-enable` のブロック囲みで抑制し、判断理由・再検討タイミングをコメントで併記する。

## 背景
`npm run lint` で `src/App.tsx` の useEffect に以下の警告が検出されている。
- `react-hooks/set-state-in-effect`：useEffect 内で `setSelectedId(null)` を直接呼び出している
- `react-hooks/exhaustive-deps`：依存配列から `selectedId` を意図的に除外している

該当 useEffect は「fetch 結果が更新された際、選択中の喫煙所 id が新しいデータに含まれていなければ選択を解除する」処理であり、フィルターで弾かれた喫煙所の選択状態をリセットする UX を実現している。この挙動を維持するため、警告を disable コメントで抑制する。

## 内容
- 該当 useEffect を `/* eslint-disable react-hooks/set-state-in-effect, react-hooks/exhaustive-deps */` と `/* eslint-enable react-hooks/set-state-in-effect, react-hooks/exhaustive-deps */` で囲み、警告を抑制
- 抑制範囲を useEffect 1 つに限定（警告が effect 内部と依存配列の 2 箇所に分かれており、`eslint-disable-next-line` では両方を抑制できないためブロック囲みを採用）
- disable の判断理由・再検討タイミングをコメントで併記
- 既存の日本語コメントを確定版コメントに置き換え

## 検討した代替案
現状の挙動（フィルター後のデータに選択中の喫煙所が含まれなければ選択解除、含まれれば維持。フィルター解除時に選択は復活しない）を維持する前提で、以下を検討し、いずれも採用しなかった。
- レンダー中の派生計算（useMemo 等）：useEffect は不要になるが、`selectedId` 自体は state として残るため、フィルター解除でデータに戻った際に選択状態が復活する。現状の「復活しない」挙動と異なる
- useEffect 削除：派生計算と同様、`selectedId` が残り続けるため挙動が変わる
- イベントハンドラへの移動：フィルター変更が要因で選択解除することになり、「データに含まれる場合は選択維持」という現状の挙動を再現できない

現状の挙動は「fetch 結果という外部 state と `selectedId` の整合性を取る」処理であり、これを維持するには useEffect 内での setState が必要。設計判断として disable を採用した。再検討は今後の機能拡張時に、TanStack Query 採用を含めて行う。

## 動作確認
- `npm run lint` で本 PR 起因のエラー・警告が解消されていること（対象 2 ルールが消えること）を確認
- アプリを起動し以下を行い、フィルター操作時の挙動が変わっていないことを確認
  - 紙タバコ含む喫煙所を選択中に紙タバコフィルター押下し、フィルター解除後も選択が維持されていることを確認
  - 電子タバコのみ喫煙所を選択中に電子タバコのみフィルター押下し、フィルター解除後に選択が維持されていることを確認
  - 紙タバコ含む喫煙所を選択中に電子タバコのみフィルター押下し、フィルター解除後に選択が解除されていることを確認
  - 電子タバコのみ喫煙所を選択中に紙タバコフィルター押下し、フィルター解除後に選択が解除されていることを確認
- `npm run build` がエラーなく完了することを確認

## 影響範囲
- アプリ機能/API：影響なし（挙動・見た目とも変更なし。lint 警告の抑制のみ）
- データ移行：不要
- DB 変更：なし

## 関連Issue
Closes #89 