### PR TITLE
chore: Add ESLint disable comments for useEffect in useSmokingAreas

### DIFF
--- a/frontend/src/features/smokingAreas/hooks/useSmokingAreas.ts
+++ b/frontend/src/features/smokingAreas/hooks/useSmokingAreas.ts
@@ -22,9 +22,15 @@ export const useSmokingAreas = (params?: SmokingAreaSearchParams): UseSmokingAre
     }
   };
 
+  /* eslint-disable react-hooks/set-state-in-effect, react-hooks/exhaustive-deps */
+  // フィルター変更時に喫煙所データを取得する。
+  // refetch内のloading遷移はレンダー内計算で再現できず、useEffectの正当な用途。
+  // refetchはレンダリングごとに再生成され、依存配列に入れると無限ループになるため除外。
+  // 機能拡張時に TanStack Query を採用し、loading遷移・喫煙所データ取得・キャッシュ管理を委譲する設計に変更するかを検討。
   useEffect(() => {
     refetch();
   }, [params?.tobaccoTypeId, params?.electronicOnly]);
+  /* eslint-enable react-hooks/set-state-in-effect, react-hooks/exhaustive-deps */
 
   return { state, refetch };
 };


### PR DESCRIPTION
## 概要
`useSmokingAreas.ts` の喫煙所データ取得用 useEffect で発生していた lint 2 件（set-state-in-effect / exhaustive-deps）に対し、ブロック囲みの disable コメントと抑制理由・再検討タイミングを追加して lint をクリーンにした。挙動・公開 API（refetch）は変更していない。

## 背景
#89 で App.tsx の同種 useEffect に同方式（ブロック囲み disable + 理由併記）を採用済み。useSmokingAreas 側は外部システム（サーバー fetch）との同期にあたる useEffect の正当な用途ではあるが、自前の refetch 構成のため 2 件の警告が残る。
`exhaustive-deps` は useCallback で技術的に解消可能ではあるが、useEffect の依存配列が `refetch` へ間接化し、機能拡張時に採用を検討する TanStack Query の queryKey での設計思想からも離れることになるため見送る。`set-state-in-effect` はどの安定化策でも残るため 1 件は disable コメントが必要になる。よって 2 件まとめて理由付き disable とし、TanStack Query は機能拡張時に採用を検討する。App.tsxと同様に、機能拡張時に TanStack Query を導入した場合、loading遷移・喫煙所データ取得・キャッシュ管理を委譲することで対応する。

## 内容
- 該当 useEffect を `/* eslint-disable react-hooks/set-state-in-effect, react-hooks/exhaustive-deps */` と `/* eslint-enable react-hooks/set-state-in-effect, react-hooks/exhaustive-deps */` で囲み、以下のコメント併記した。
  - フィルター変更時に喫煙所データを取得する処理であること
  - `set-state-in-effect` の抑制理由
  - `exhaustive-deps` の抑制理由
  - 再検討タイミング（ 機能拡張時に TanStack Query の採用を検討する旨）

## 検討した代替案
`exhaustive-deps`（依存配列に `refetch` が含まれていない）は、以下の方法で技術的には解消可能だったが、いずれも採用しなかった。

- useCallback で refetch を安定化：params は App.tsx 側で useState 管理の安定参照のため、useCallback (依存配列に `params` ) で refetch を安定化でき、useEffect の依存配列を `refetch` にすればLintエラーは消える。しかし useEffect の発火条件が `[tobaccoTypeId, electronicOnly]` から `[refetch]` へ間接化し、「何が変わったら再実行されるか」が依存配列だけでは読めなくなる（発火条件の宣言が useCallback 側へ分割される）。また機能拡張時に採用を検討する TanStack Query の queryKey 設計思想（プリミティブな値）からも離れる方向になる。 
- useRef で params を保持：refetch が params を直接参照せず ref 経由で読むことで params への依存を切れるが、useEffect が params に依存していることを依存配列から読めず ref 内に隠れてしまい、データフローの追跡性が下がってしまう。実質「Lintエラーを黙らせるための小細工」であり、理由を明記した disable より適切ではないと判断。

加えて `set-state-in-effect`（refetch 関数内の setState）は上記いずれの安定化策でも残るため、最良でも 1 件は disable が必要。よって 2 件まとめて理由付き disable とし、App.tsx の同種 useEffect とも対処を揃えた。

## 動作確認
- `npm run lint` を実行し、該当 2 件のエラーが解消されていることを確認
- アプリを起動し以下を確認
  - アプリ起動時に喫煙所マーカー一覧が表示されることを確認
  - 紙タバコフィルターを押下し、紙タバコ対応の喫煙所が表示されることを確認
  - 紙タバコフィルターを再度押下し、すべての喫煙所が表示されることを確認
  - 電子タバコのみフィルターを押下し、電子タバコのみ対応の喫煙所が表示されることを確認
  - 電子タバコのみフィルターを再度押下し、すべての喫煙所が表示されることを確認

## 影響範囲
- アプリ機能/API：影響なし（コメント追加のみ、ロジック・型・公開 API に変更なし）
- データ移行：不要
- DB変更：なし

## 関連Issue
Closes #91 