### PR TITLE
Refactor/93 tobacco types state

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -25,7 +25,7 @@ export default function App() {
 
   return (
     <SmokingAreasMap
-      state={state}
+      smokingAreasState={state}
       selectedId={selectedId}
       setSelectedId={setSelectedId}
       params={params}

--- a/frontend/src/SmokingAreasMap.tsx
+++ b/frontend/src/SmokingAreasMap.tsx
@@ -1,5 +1,5 @@
 import { APIProvider, Map, AdvancedMarker, MapControl, ControlPosition, useMap } from "@vis.gl/react-google-maps";
-import { TobaccoTypeFilter } from "./TobaccoTypeFilter"
+import { TobaccoTypeFilter } from "./TobaccoTypeFilter";
 import { useTobaccoTypes } from "./features/smokingAreas/hooks/useTobaccoTypes";
 import { useEffect, useRef, useState } from "react";
 import { LocateFixed, Maximize, Minimize } from "lucide-react";
@@ -10,7 +10,7 @@ type SmokingAreasMapProps = {
   smokingAreasState: FetchState<SmokingAreaDisplay[]>;
   selectedId: number | null;
   setSelectedId: (id: number | null) => void;
-  params: SmokingAreaSearchParams
+  params: SmokingAreaSearchParams;
   setParams: (params: SmokingAreaSearchParams) => void;
   refetchSmokingAreas: () => Promise<void>;
 };
@@ -64,7 +64,7 @@ export const SmokingAreasMap = ({ smokingAreasState, selectedId, setSelectedId, 
     const handleResize = () => setIsMobile(window.innerWidth < 1025);
     window.addEventListener("resize", handleResize);
     return () => window.removeEventListener("resize", handleResize);
-  }, [])
+  }, []);
 
   useEffect(() => {
     navigator.geolocation.getCurrentPosition((position) => {
@@ -119,7 +119,7 @@ export const SmokingAreasMap = ({ smokingAreasState, selectedId, setSelectedId, 
           defaultZoom={16}
           mapId={mapId}
           disableDefaultUI={true}
-          zoomControl={isMobile ? false : true}
+          zoomControl={!isMobile}
           clickableIcons={false}
           keyboardShortcuts={false}
           draggableCursor="default"
@@ -131,8 +131,8 @@ export const SmokingAreasMap = ({ smokingAreasState, selectedId, setSelectedId, 
           {smokingAreasState.status === "success" && tobaccoTypesState.status === "success" && smokingAreasState.data.map((smokingArea) => {
             const isSelected = selectedId === smokingArea.id;
             return (
-              <AdvancedMarker 
-                key={smokingArea.id} 
+              <AdvancedMarker
+                key={smokingArea.id}
                 position={{ lat: smokingArea.latitude, lng: smokingArea.longitude}}
                 onClick={() => setSelectedId(isSelected ? null : smokingArea.id)}
                 zIndex={isSelected ? 5 : 0}>

--- a/frontend/src/SmokingAreasMap.tsx
+++ b/frontend/src/SmokingAreasMap.tsx
@@ -7,7 +7,7 @@ import type { SmokingAreaDisplay, SmokingAreaSearchParams } from "./features/smo
 import type { FetchState } from "./types/fetchState";
 
 type SmokingAreasMapProps = {
-  state: FetchState<SmokingAreaDisplay[]>;
+  smokingAreasState: FetchState<SmokingAreaDisplay[]>;
   selectedId: number | null;
   setSelectedId: (id: number | null) => void;
   params: SmokingAreaSearchParams
@@ -33,7 +33,7 @@ const CurrentLocationHandler = ({ position }: { position: { lat: number, lng: nu
   );
 };
 
-export const SmokingAreasMap = ({ state, selectedId, setSelectedId, params, setParams, refetchSmokingAreas }: SmokingAreasMapProps) => {
+export const SmokingAreasMap = ({ smokingAreasState, selectedId, setSelectedId, params, setParams, refetchSmokingAreas }: SmokingAreasMapProps) => {
   const apiKey = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
   const mapId = import.meta.env.VITE_GOOGLE_MAPS_MAP_ID;
 

--- a/frontend/src/SmokingAreasMap.tsx
+++ b/frontend/src/SmokingAreasMap.tsx
@@ -43,7 +43,22 @@ export const SmokingAreasMap = ({ smokingAreasState, selectedId, setSelectedId, 
 
   const mapContainerRef = useRef<HTMLDivElement>(null);
 
-  const { data: tobaccoTypes, refetch: refetchTobaccoTypes } = useTobaccoTypes();
+  const { state: tobaccoTypesState, refetch: refetchTobaccoTypes } = useTobaccoTypes();
+
+  const renderOverlay = () => {
+    if (smokingAreasState.status === "error" || tobaccoTypesState.status === "error") {
+      return (
+        <div className="error-overlay">
+          <p>データの取得に失敗しました</p>
+          <button onClick={() => { refetchSmokingAreas(); refetchTobaccoTypes(); }}>再取得</button>
+        </div>
+      );
+    }
+    if (smokingAreasState.status === "loading" || tobaccoTypesState.status === "loading") {
+      return <div className="loading-overlay">Loading...</div>;
+    }
+    return null;
+  };
 
   useEffect(() => {
     const handleResize = () => setIsMobile(window.innerWidth < 1025);
@@ -95,12 +110,7 @@ export const SmokingAreasMap = ({ smokingAreasState, selectedId, setSelectedId, 
           {isFullscreen ? <Minimize size={20}/> : <Maximize size={20}/>}
         </button>
       )}
-      {state.status === "loading" && <div className="loading-overlay">Loading...</div>}
-      {state.status === "error" &&
-        <div className="error-overlay">
-          <p>データの取得に失敗しました</p>
-          <button onClick={() => { refetchSmokingAreas(); refetchTobaccoTypes(); }}>再取得</button>
-        </div>}
+      {renderOverlay()}
       <APIProvider apiKey={apiKey} libraries={['marker']}>
         <Map
           defaultCenter={defaultCenter}

--- a/frontend/src/SmokingAreasMap.tsx
+++ b/frontend/src/SmokingAreasMap.tsx
@@ -74,8 +74,8 @@ export const SmokingAreasMap = ({ smokingAreasState, selectedId, setSelectedId, 
 
   const getSelectedSmokingArea = (): SmokingAreaDisplay | null => {
     if (selectedId === null) return null;
-    if (state.status !== "success") return null;
-    return state.data.find((smokingArea) => smokingArea.id === selectedId) ?? null;
+    if (smokingAreasState.status !== "success") return null;
+    return smokingAreasState.data.find((smokingArea) => smokingArea.id === selectedId) ?? null;
   };
 
   const toggleFullscreen = () => {
@@ -94,11 +94,13 @@ export const SmokingAreasMap = ({ smokingAreasState, selectedId, setSelectedId, 
 
   const selectedSmokingArea = getSelectedSmokingArea();
 
-  const selectedTobaccoTypeIds = selectedSmokingArea?.tobaccoTypeIds ?? []
-  const selectedTobaccoTypes = tobaccoTypes.filter((tobaccoType) => selectedTobaccoTypeIds.includes(tobaccoType.id))
+  const selectedTobaccoTypeIds = selectedSmokingArea?.tobaccoTypeIds ?? [];
+  const selectedTobaccoTypes = tobaccoTypesState.status === "success" ? tobaccoTypesState.data
+                               .filter((tobaccoType) => selectedTobaccoTypeIds
+                               .includes(tobaccoType.id))
                                .sort((a, b) => a.displayOrder - b.displayOrder)
                                .map((tobaccoType) => tobaccoType.name)
-                               .join(", ");
+                               .join(", ") : "";
 
   const defaultCenter = { lat: 35.6812, lng: 139.7671 };
 
@@ -126,7 +128,7 @@ export const SmokingAreasMap = ({ smokingAreasState, selectedId, setSelectedId, 
           onClick={() => setSelectedId(null)}>
           <CurrentLocationHandler position={position}/>
           {position && <AdvancedMarker position={position}/>}
-          {state.status === "success" && state.data.map((smokingArea) => {
+          {smokingAreasState.status === "success" && tobaccoTypesState.status === "success" && smokingAreasState.data.map((smokingArea) => {
             const isSelected = selectedId === smokingArea.id;
             return (
               <AdvancedMarker 

--- a/frontend/src/features/smokingAreas/hooks/useTobaccoTypes.ts
+++ b/frontend/src/features/smokingAreas/hooks/useTobaccoTypes.ts
@@ -22,9 +22,14 @@ export const useTobaccoTypes = (): UseTobaccoTypesResult => {
     }
   };
 
+  /* eslint-disable react-hooks/set-state-in-effect */
+  // 初回マウント時に一度だけデータを取得する。
+  // refetch内のloading遷移はレンダー内計算で再現できず、useEffectの正当な用途。
+  // 機能拡張時に TanStack Query を採用し、loading遷移・タバコ種別取得・キャッシュ管理を委譲する設計に変更するかを検討。
   useEffect(() => {
     refetch();
   }, []);
+  /* eslint-enable react-hooks/set-state-in-effect */
 
   return { state, refetch };
 };

--- a/frontend/src/features/smokingAreas/hooks/useTobaccoTypes.ts
+++ b/frontend/src/features/smokingAreas/hooks/useTobaccoTypes.ts
@@ -1,19 +1,30 @@
 import type { TobaccoType } from "../../../features/smokingAreas/types";
 import { useState, useEffect } from "react";
 import { fetchTobaccoTypes } from "../../../api/tobaccoTypes/client";
+import type { FetchState } from "../../../types/fetchState";
+import { toError } from "./toError";
 
-export const useTobaccoTypes = () => {
-  const [data, setData] = useState<TobaccoType[]>([]);
+type UseTobaccoTypesResult = {
+  state: FetchState<TobaccoType[]>;
+  refetch: () => Promise<void>;
+};
 
-  const refetch = () => {
-    fetchTobaccoTypes()
-      .then(setData)
-      .catch(() => {});
+export const useTobaccoTypes = (): UseTobaccoTypesResult => {
+  const [state, setState] = useState<FetchState<TobaccoType[]>>({ status: "loading" })
+
+  const refetch = async () => {
+    setState({ status: "loading" });
+    try {
+      const tobaccoTypes = await fetchTobaccoTypes();
+      setState({ status: "success", data: tobaccoTypes });
+    } catch (e) {
+      setState({ status: "error", error: toError(e) });
+    }
   };
 
   useEffect(() => {
     refetch();
   }, []);
 
-  return { data, refetch };
+  return { state, refetch };
 };


### PR DESCRIPTION
## 概要
`useTobaccoTypes` の状態管理を `FetchState<T>` に統一し、喫煙所・タバコ種別のどちらかが取得に失敗した場合は既存のエラー表示に統合する。両方が `success` のときのみマップを表示する。

## 背景
`useTobaccoTypes` は静的マスターデータのため状態遷移を意識する必要がないと判断し、`FetchState<T>` の対象外として個別データで扱っていた。

その後、サーバー停止中の再取得でポップアップの「対応：」が空表示になるバグが発生。直接の原因は、`App.tsx` が `useTobaccoTypes` の返り値から `data` のみを受け取り、`refetch` を受け取っていなかったこと。再取得ボタンを押してもタバコ種別は再取得されず、失敗時の空配列がポップアップに渡って空表示になっていた。

このバグは、`App.tsx` で `refetch` を受け取り、再取得ボタンで喫煙所・タバコ種別の両方を再取得するよう変更して解消済み。ただしこの対処は再取得の成功時しか想定しておらず、`useTobaccoTypes` 内の `catch(() => {})` で取得失敗を握り潰す実装にしており、`error` が処理側に伝わらない問題があった。

テストケース選定の過程でこの握り潰しに気づき、修正対象と判断。「喫煙所・タバコ種別の両方が `success` で表示、どちらかが `error` なら既存のエラー表示」と設計意図を明確にしこれを満たすには、タバコ種別の `loading` / `success` / `error` を処理側が判別する必要があり、#80で外した「`FetchState<T>` で包まない」判断を、前提変更（状態の変化が処理側にとって意味を持つようになったこと）を理由に再導入する。なお「独立した loading UI を持たせない」判断は維持し、`loading` は喫煙所側の表示に畳む。

## 内容
- `useTobaccoTypes.ts` 内の記述を以下のように変更
  - 状態管理を個別 state から `FetchState<T>` 単一 state に変更
  - 関数 `refetch` を `status: "loading"` に遷移させ、`async` / `await` + `try...catch` で取得の処理を分岐
  - error は data を持たない標準形とし、エラー時のデータ保持は行わない
  - カスタムフックの返り値の型、`UseTobaccoTypesResult` を定義
  - 返り値を `{ state, refetch }` に変更 
  - useEffect を `/* eslint-disable react-hooks/set-state-in-effect */` と `/* eslint-enable react-hooks/set-state-in-effect */` で囲み、以下のコメント併記
    - 初回マウント時に一度だけデータを取得する処理であること
    - `set-state-in-effect` の抑制理由
    - 再検討タイミング（ 機能拡張時に TanStack Query の採用を検討する旨）
- `App.tsx` の `SmokingAreasMap.tsx` に渡す prop 名を `state` から `smokingAreasState` に変更
- `SmokingAreasMap.tsx` 内の記述を以下のように変更
  - `App.tsx` から渡ってきた prop 名を `state` から `smokingAreasState` に変更
  - `renderOverlay` 関数を定義し、`status` のどちらかが `error` の時のエラー表示（喫煙所とタバコ種別の両方を再取得）と、どちらかが `loading` 中の時のローディング表示をまとめ、JSX 内で実行
  - `status` の両方が `success` の時マップ表示
  - `getSelectedSmokingArea` 内の `state` を `smokingAreasState` に変更
  - `selectedTobaccoTypes` の判定を三項演算子に変更し、 `tobaccoTypesState.status` が `success` の時にデータを格納し、他の場合は空文字を格納するよう変更
  - `zoomControl` 内の `isMobile` 判定を三項演算子からノット演算子に変更
  - 不要なスペースを削除し、不足していたセミコロンを追加

## 動作確認
- タバコ種別エンドポイントのみ失敗させた状態で、初期表示及び再取得の両方でエラー表示に落ちることを確認
- 喫煙所データのみ失敗時も同様にエラー表示に落ちることを確認
- rails サーバーを停止後エラー表示が出ることを確認し、サーバーを再起動させ以下を確認
  - エラー表示から再取得ボタンを押下し両データが再取得され、マップ、喫煙所マーカーが表示されることを確認
  - 各喫煙所ごとのポップアップ内表示のタバコ種別が正しく表示されることを確認（旧バグの回帰確認）

## 影響範囲
- アプリ機能/API：影響あり（エラー・ローディングのオーバーレイ表示）
- データ移行：不要
- DB変更：なし  

## 関連Issue
Closes #93 