### PR TITLE
docs: remove TanStack Query from useEffect comment in App.tsx

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,7 +13,6 @@ export default function App() {
   // フィルター後のデータに選択中の喫煙所が含まれなければ選択状態を解除する。
   // これによりフィルター解除時に選択状態が復活しない。
   // レンダー内計算だと解除時に selectedId が残り選択状態が復活するため、意図的に Effect 内で更新。
-  // 機能拡張時に TanStack Query を採用し、サーバーサイドでフィルター後の状態を管理する設計に変更するかを検討。
   // selectedId の変化には反応不要のため依存配列から除外。
   useEffect(() => {
     if (selectedId === null) return;


### PR DESCRIPTION
## 概要
`App.tsx` の選択解除 useEffect に付与しているコメントに、TanStack Query の役割を誤解した記述がある。事実として誤っているため修正する。

## 背景
現在のコメントに以下の記述がある。

`機能拡張時に TanStack Query を採用し、サーバーサイドでフィルター後の状態を管理する設計に変更するかを検討。`

TanStack Query はサーバー状態のキャッシュライブラリであり、selectedId のようなクライアント状態は管理対象外。したがって TanStack Query を導入してもこの useEffect は不要にならない。検討事項として成立していないため削除する。

## 内容
- `App.tsx` の useEffect コメントから TanStack Query に関する記述を削除する

## 動作確認
- `npm run lint` が通ること
- `npm run test` が通ること

## 影響範囲
- アプリ機能/API：なし
- データ移行：なし
- DB変更：なし

## 関連Issue
Closes #105 