### PR TITLE
Test/110 fix request specs to match implementation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ group :development, :test do
   gem "debug", platforms: %i[ mri windows ]
   gem "rspec-rails"
   gem "dotenv-rails"
+  gem "factory_bot_rails"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,11 @@ GEM
     drb (2.2.3)
     erb (5.0.1)
     erubi (1.13.1)
+    factory_bot (6.6.0)
+      activesupport (>= 6.1.0)
+    factory_bot_rails (6.5.1)
+      factory_bot (~> 6.5)
+      railties (>= 6.1.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.7)
@@ -248,6 +253,7 @@ DEPENDENCIES
   bootsnap
   debug
   dotenv-rails
+  factory_bot_rails
   pg (~> 1.1)
   puma (>= 5.0)
   rack-cors

--- a/spec/factories/smoking_areas.rb
+++ b/spec/factories/smoking_areas.rb
@@ -1,0 +1,18 @@
+FactoryBot.define do
+  factory :smoking_area do
+    sequence(:name) { |n| "喫煙所#{n}" }
+    latitude        { 35.690 }
+    longitude       { 139.700 }
+
+    trait :with_both do
+      tobacco_type_ids do
+        [ TobaccoType.find_by!(name: "紙タバコ").id,
+          TobaccoType.find_by!(name: "電子タバコ").id ]
+      end
+    end
+
+    trait :electronic_only do
+      tobacco_type_ids { [ TobaccoType.find_by!(name: "電子タバコ").id ] }
+    end
+  end
+end

--- a/spec/factories/tobacco_types.rb
+++ b/spec/factories/tobacco_types.rb
@@ -1,0 +1,20 @@
+FactoryBot.define do
+  factory :tobacco_type do
+    # name / display_order は一意制約があるため、既定値は sequence で衝突を避ける
+    sequence(:name)          { |n| "タバコ種別#{n}" }
+    icon                     { "cigarette" }
+    sequence(:display_order) { |n| n + 100 }
+
+    trait :paper do
+      name          { "紙タバコ" }
+      icon          { "cigarette" }
+      display_order { 1 }
+    end
+
+    trait :electronic do
+      name          { "電子タバコ" }
+      icon          { "electronic cigarette" }
+      display_order { 2 }
+    end
+  end
+end

--- a/spec/models/smoking_area_spec.rb
+++ b/spec/models/smoking_area_spec.rb
@@ -1,0 +1,131 @@
+require 'rails_helper'
+
+RSpec.describe SmokingArea, type: :model do
+  describe "validations" do
+    let!(:paper) { create(:tobacco_type, :paper) }
+    let!(:electronic) { create(:tobacco_type, :electronic)}
+
+    it "is valid with default attributes" do
+      smoking_area = build(:smoking_area)
+      expect(smoking_area).to be_valid
+    end
+
+    it "is invalid without a name" do
+      smoking_area = build(:smoking_area, name: nil)
+      expect(smoking_area).to be_invalid
+      expect(smoking_area.errors).to be_of_kind(:name, :blank)
+    end
+
+    it "is invalid when the name is longer than 100 characters" do
+      smoking_area = build(:smoking_area, name: "a" * 100)
+      expect(smoking_area).to be_valid
+
+      smoking_area = build(:smoking_area, name: "a" * 101)
+      expect(smoking_area).to be_invalid
+    end
+
+    it "is invalid without a latitude" do
+      smoking_area = build(:smoking_area, latitude: nil)
+      expect(smoking_area).to be_invalid
+    end
+
+    it "is invalid without a longitude" do
+      smoking_area = build(:smoking_area, longitude: nil)
+      expect(smoking_area).to be_invalid
+    end
+
+    it "is invalid when the latitude is out of the -90..90 range" do
+      smoking_area = build(:smoking_area, latitude: 90.1)
+      expect(smoking_area).to be_invalid
+
+      smoking_area = build(:smoking_area, latitude: -90.1)
+      expect(smoking_area).to be_invalid
+
+      smoking_area = build(:smoking_area, latitude: 90)
+      expect(smoking_area).to be_valid
+    end
+
+    it "is invalid when the longitude is out of the -180..180 range" do
+      smoking_area = build(:smoking_area, longitude: 180.1)
+      expect(smoking_area).to be_invalid
+
+      smoking_area = build(:smoking_area, longitude: -180.1)
+      expect(smoking_area).to be_invalid
+
+      smoking_area = build(:smoking_area, longitude: 180)
+      expect(smoking_area).to be_valid
+    end
+
+    it "allows true, false and nil for is_indoor" do
+      smoking_area = build(:smoking_area, is_indoor: true)
+      expect(smoking_area).to be_valid
+
+      smoking_area = build(:smoking_area, is_indoor: false)
+      expect(smoking_area).to be_valid
+
+      smoking_area = build(:smoking_area, is_indoor: nil)
+      expect(smoking_area).to be_valid
+    end
+
+    it "is invalid when the address is longer than 255 characters" do
+      smoking_area = build(:smoking_area, address: "a" * 255)
+      expect(smoking_area).to be_valid
+
+      smoking_area = build(:smoking_area, address: "a" * 256)
+      expect(smoking_area).to be_invalid
+    end
+
+    it "is invalid when the detail is longer than 2000 characters" do
+      smoking_area = build(:smoking_area, detail: "a" * 2000)
+      expect(smoking_area).to be_valid
+
+      smoking_area = build(:smoking_area, detail: "a" * 2001)
+      expect(smoking_area).to be_invalid
+    end
+  end
+
+  describe "normalize_tobacco_types" do
+    context "when both paper and electronic master records exist" do
+      let!(:paper) { create(:tobacco_type, :paper) }
+      let!(:electronic) { create(:tobacco_type, :electronic)}
+
+      it "assigns both tobacco types when none are given" do
+        smoking_area = create(:smoking_area)
+        expect(smoking_area.tobacco_type_ids).to match_array([paper.id, electronic.id])
+      end
+
+      it "adds the electronic type when only the paper type is given" do
+        smoking_area = create(:smoking_area, tobacco_type_ids: [paper.id])
+        expect(smoking_area.tobacco_type_ids).to match_array([paper.id, electronic.id])
+      end
+
+      it "keeps only the electronic type when only the electronic type is given" do
+        smoking_area = create(:smoking_area, :electronic_only)
+        expect(smoking_area.tobacco_type_ids).to match_array([electronic.id])
+      end
+    end
+
+    context "when the master records do not exist" do
+      it "is invalid because no tobacco type is assigned" do
+        smoking_area = build(:smoking_area)
+        expect(smoking_area).to be_invalid
+        expect(smoking_area.errors[:tobacco_types]).to be_present
+      end
+    end
+  end
+
+  describe "associations" do
+    let!(:electronic) { create(:tobacco_type, :electronic)}
+    let!(:paper) { create(:tobacco_type, :paper) }
+
+    it "returns tobacco types ordered by display_order" do
+      smoking_area = create(:smoking_area, :with_both)
+      expect(smoking_area.tobacco_types).to eq [paper, electronic]
+    end
+
+    it "destroys the join records when the smoking area is destroyed" do
+      smoking_area = create(:smoking_area, :with_both)
+      expect{ smoking_area.destroy } .to change(SmokingAreaTobaccoType, :count).by(-2)
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -37,6 +37,7 @@ RSpec.configure do |config|
   config.fixture_paths = [
     Rails.root.join('spec/fixtures')
   ]
+  config.include FactoryBot::Syntax::Methods
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false

--- a/spec/requests/v1/smoking_areas_spec.rb
+++ b/spec/requests/v1/smoking_areas_spec.rb
@@ -1,182 +1,55 @@
 require 'rails_helper'
 
 RSpec.describe "V1::SmokingAreas", type: :request do
+  let!(:paper)      { create(:tobacco_type, :paper) }
+  let!(:electronic) { create(:tobacco_type, :electronic) }
+
   describe "GET /v1/smoking_areas" do
-    it "returns smoking areas" do
-
-      electronic = TobaccoType.create!(name: "電子タバコ", icon: "electronic cigarette", display_order: 2)
-      paper      = TobaccoType.create!(name: "紙タバコ",   icon: "cigarette",            display_order: 1)
-      
-      smoking_area1 = SmokingArea.create!(name: "新宿東口喫煙所",       latitude: 36.666333,  longitude: 135.343434)
-      smoking_area2 = SmokingArea.create!(name: "鳥貴族町田北口店",     latitude: 35.123456,  longitude: 134.987654)
-      smoking_area3 = SmokingArea.create!(name: "ニトリモール相模原1F", latitude: 35.555555,  longitude: 139.777333)
-
-      SmokingAreaTobaccoType.create!(smoking_area: smoking_area1, tobacco_type: paper)
-      SmokingAreaTobaccoType.create!(smoking_area: smoking_area1, tobacco_type: electronic)
-      SmokingAreaTobaccoType.create!(smoking_area: smoking_area2, tobacco_type: paper)
-      SmokingAreaTobaccoType.create!(smoking_area: smoking_area2, tobacco_type: electronic)
-      SmokingAreaTobaccoType.create!(smoking_area: smoking_area3, tobacco_type: electronic)
+    it "returns smoking areas ordered by id" do
+      area_both   = create(:smoking_area, :with_both, name: "新宿東口喫煙所")
+      area_e_only = create(:smoking_area, :electronic_only, name: "町田駅北口喫煙所")
 
       get "/v1/smoking_areas"
 
       expect(response).to have_http_status(:ok)
-
       json = JSON.parse(response.body)
 
-      expect(json.size).to eq 3
-      expect(json.map { |smoking_area_json| smoking_area_json["name"] }).to eq [
-        smoking_area1.name,
-        smoking_area2.name,
-        smoking_area3.name
-      ]
+      expect(json.size).to eq 2
+      expect(json.map { |a| a["name"] }).to eq [area_both.name, area_e_only.name]
 
       first = json.first
-      expect(first["tobacco_type_ids"]).to eq [paper.id, electronic.id]
-      second = json.second
-      expect(second["tobacco_type_ids"]).to eq [paper.id, electronic.id]
-
-      json.each do |smoking_area_json|
-        expect(smoking_area_json.keys.sort).to eq %w[id name latitude longitude tobacco_type_ids].sort
-      end
+      expect(first.keys.sort).to eq %w[id name latitude longitude tobacco_type_ids].sort
+      expect(first["latitude"]).to be_a(String)
+      expect(first["longitude"]).to be_a(String)
+      expect(first["latitude"].to_f).to eq area_both.latitude.to_f
+      expect(first["longitude"].to_f).to eq area_both.longitude.to_f
+      expect(first["tobacco_type_ids"]).to match_array [paper.id, electronic.id]
     end
 
     it "filters smoking areas by tobacco_type_id" do
-      electronic = TobaccoType.create!(name: "電子タバコ", icon: "electronic cigarette", display_order: 2)
-      paper      = TobaccoType.create!(name: "紙タバコ",   icon: "cigarette",            display_order: 1)
-      
-      smoking_area1 = SmokingArea.create!(name: "新宿東口喫煙所",       latitude: 36.666333,  longitude: 135.343434)
-      smoking_area2 = SmokingArea.create!(name: "鳥貴族町田北口店",     latitude: 35.123456,  longitude: 134.987654)
-      smoking_area3 = SmokingArea.create!(name: "ニトリモール相模原1F", latitude: 35.555555,  longitude: 139.777333)
-
-      SmokingAreaTobaccoType.create!(smoking_area: smoking_area1, tobacco_type: paper)
-      SmokingAreaTobaccoType.create!(smoking_area: smoking_area1, tobacco_type: electronic)
-      SmokingAreaTobaccoType.create!(smoking_area: smoking_area2, tobacco_type: paper)
-      SmokingAreaTobaccoType.create!(smoking_area: smoking_area2, tobacco_type: electronic)
-      SmokingAreaTobaccoType.create!(smoking_area: smoking_area3, tobacco_type: electronic)
+      area_shinjuku = create(:smoking_area, :with_both, name: "新宿東口喫煙所")
+      area_tokyo = create(:smoking_area, :with_both, name: "東京駅丸の内喫煙所")
+      create(:smoking_area, :electronic_only, name: "町田駅北口喫煙所")
 
       get "/v1/smoking_areas", params: { tobacco_type_id: paper.id }
 
       expect(response).to have_http_status(:ok)
-
       json = JSON.parse(response.body)
 
-      # 紙タバコに紐づく喫煙所だけが返ること
-      expect(json.size).to eq 2
-      expect(json.map { |smoking_area_json| smoking_area_json["name"] }).to match_array [
-        smoking_area1.name,
-        smoking_area2.name
-      ]
-      json.each do |smoking_area_json|
-        expect(smoking_area_json["tobacco_type_ids"]).to include(paper.id)
-      end
+      expect(json.map { |a| a["name"] }).to contain_exactly(area_shinjuku.name, area_tokyo.name)
     end
 
-    it "filters smoking areas by query on name" do
-      electronic = TobaccoType.create!(name: "電子タバコ", icon: "electronic cigarette", display_order: 2)
-      paper      = TobaccoType.create!(name: "紙タバコ",   icon: "cigarette",            display_order: 1)
-      
-      shinjuku_east   = SmokingArea.create!(name: "新宿東口喫煙所",    latitude: 36.666333, longitude: 135.343434)
-      shinjuku_sanchome = SmokingArea.create!(name: "新宿三丁目喫煙所", latitude: 36.666334, longitude: 135.343435)
-      machida_north   = SmokingArea.create!(name: "町田駅北口喫煙所",  latitude: 35.123456, longitude: 134.987654)
+    it "returns only electronic-only smoking areas when electronic_only is true" do
+      create(:smoking_area, :with_both, name: "新宿東口喫煙所")
+      area_machida = create(:smoking_area, :electronic_only, name: "町田駅北口喫煙所")
+      area_yokohama = create(:smoking_area, :electronic_only, name: "横浜駅西口喫煙所")
 
-      [shinjuku_east, shinjuku_sanchome, machida_north].each do |area|
-        SmokingAreaTobaccoType.create!(smoking_area: area, tobacco_type: paper)
-        SmokingAreaTobaccoType.create!(smoking_area: area, tobacco_type: electronic)
-      end
-
-      get "/v1/smoking_areas", params: { query: "新宿" }
+      get "/v1/smoking_areas", params: { electronic_only: "true" }
 
       expect(response).to have_http_status(:ok)
-
       json = JSON.parse(response.body)
 
-      # name に「新宿」を含む喫煙所だけが返ること
-      expect(json.size).to eq 2
-      expect(json.map { |smoking_area_json| smoking_area_json["name"] }).to match_array [
-        shinjuku_east.name,
-        shinjuku_sanchome.name
-      ]
-    end
-
-    it "filters smoking areas by both tobacco_type_id and query" do
-      electronic = TobaccoType.create!(name: "電子タバコ", icon: "electronic cigarette", display_order: 2)
-      paper      = TobaccoType.create!(name: "紙タバコ",   icon: "cigarette",            display_order: 1)
-      
-      shinjuku_both = SmokingArea.create!(name: "新宿東口喫煙所",    latitude: 36.666333, longitude: 135.343434)
-      shinjuku_electronic_only = SmokingArea.create!(name: "新宿西口喫煙所", latitude: 36.666334, longitude: 135.343435)
-      machida_paper_only = SmokingArea.create!(name: "町田駅北口喫煙所",  latitude: 35.123456, longitude: 134.987654)
-
-      # 新宿東口: 紙 + 電子
-      SmokingAreaTobaccoType.create!(smoking_area: shinjuku_both, tobacco_type: paper)
-      SmokingAreaTobaccoType.create!(smoking_area: shinjuku_both, tobacco_type: electronic)
-      # 新宿西口: 電子のみ
-      SmokingAreaTobaccoType.create!(smoking_area: shinjuku_electronic_only, tobacco_type: electronic)
-      # 町田北口: 紙のみ
-      SmokingAreaTobaccoType.create!(smoking_area: machida_paper_only, tobacco_type: paper)
-
-      get "/v1/smoking_areas", params: { tobacco_type_id: paper.id, query: "新宿" }
-
-      expect(response).to have_http_status(:ok)
-
-      json = JSON.parse(response.body)
-
-      # 「新宿」を含み、かつ紙タバコに対応している喫煙所だけが返ること
-      expect(json.size).to eq 1
-      expect(json.first["name"]).to eq shinjuku_both.name
-      expect(json.first["tobacco_type_ids"]).to include(paper.id)
-    end
-  end
-
-  describe "GET /v1/smoking_areas/:id" do
-    context "when the resource exists" do
-      it "returns smoking area details" do
-      
-        paper      = TobaccoType.create!(name: "紙タバコ",   icon: "cigarette",            display_order: 1)
-        electronic = TobaccoType.create!(name: "電子タバコ", icon: "electronic cigarette", display_order: 2)
-
-        smoking_area1 = SmokingArea.create!(name: "新宿東口喫煙所", latitude: 36.666333, longitude: 135.343434, 
-                                            is_indoor: true, detail: "広い", address: "〒160-0022 東京都新宿区新宿３丁目３８")
-                                            
-        SmokingAreaTobaccoType.create!(smoking_area: smoking_area1, tobacco_type: paper)
-        SmokingAreaTobaccoType.create!(smoking_area: smoking_area1, tobacco_type: electronic)
-
-        get "/v1/smoking_areas/#{smoking_area1.id}"
-
-        expect(response).to have_http_status(:ok)
-
-        json = JSON.parse(response.body)
-
-        expect(json["id"]).to eq smoking_area1.id
-        expect(json["name"]).to eq smoking_area1.name
-        expect(json["latitude"]).to eq smoking_area1.latitude.to_s
-        expect(json["longitude"]).to eq smoking_area1.longitude.to_s
-        expect(json["is_indoor"]).to eq smoking_area1.is_indoor
-        expect(json["detail"]).to eq smoking_area1.detail
-        expect(json["address"]).to eq smoking_area1.address
-
-        tobacco_types = json["tobacco_types"]
-
-        expect(tobacco_types.size).to eq 2
-        expect(tobacco_types.map { |tobacco_type| tobacco_type["id"] }).to   eq [paper.id, electronic.id]
-        expect(tobacco_types.map { |tobacco_type| tobacco_type["name"] }).to eq ["紙タバコ", "電子タバコ"]
-        expect(tobacco_types.map { |tobacco_type| tobacco_type["icon"] }).to eq ["cigarette", "electronic cigarette"]
-      end
-    end
-    
-    context "when the resource does not exist" do
-      it "returns 404 when smoking area does not exist" do
-        non_existing_id = SmokingArea.maximum(:id).to_i + 1
-
-        get "/v1/smoking_areas/#{non_existing_id}"
-
-        expect(response).to have_http_status(:not_found)
-
-        json = JSON.parse(response.body)
-
-        expect(json["error"]["code"]).to eq "not_found"
-        expect(json["error"]["message"]).to eq "Smoking area not found."
-        expect(json["request_id"]).to be_present
-      end
+      expect(json.map { |a| a["name"] }).to contain_exactly(area_machida.name, area_yokohama.name)
     end
   end
 end


### PR DESCRIPTION
## 概要
- バックエンドの `request spec` が現在の実装と乖離しているため、実装済みの挙動に合わせて修正する。
- `factory_bot_rails` を導入してテストデータ生成を共通化し `request spec` を `factory` を使う形に書き換える。
- 未整備の `model spec` を追加する。

## 背景
- 未実装の機能（ `name` の部分一致検索 `query` / 詳細表示 `GET /v1/smoking_areas/:id` ）に対するテストが残っており、テストが失敗する。
- 実装済みの `electronic_only` フィルタにテストが無い。
- 各 `example` で `TobaccoType` / `SmokingArea` をインラインで生成しており、必須属性の記述が重複している。モデルにカラムを追加した場合、全ての生成箇所を修正する必要がある。
- `SmokingArea` にはバリデーション（ `name` / 緯度経度 / 各長さ / `is_indoor` ）と `before_validation` の `normalize_tobacco_types` による種別の自動補完があるが、これらを検証する `model spec` が存在しない。
- `normalize_tobacco_types` は「未指定なら紙と電子を付与」「紙のみなら電子を追加」という分岐を持ち、テストデータの作り方にも影響するため、挙動をテストで固定する。

## 内容
- `factory_bot_rails` を `Gemfile` 内の `:development, :test` に追加
- `rails_helper.rb` に `FactoryBot::Syntax::Methods` を追加
- `spec/requests/v1/smoking_areas_spec.rb` の内容を以下に変更
  - `query`（名称検索）のテストを削除
  - `GET /v1/smoking_areas/:id` のテストを削除
  - `factory` を使う形に書き換え
  - 緯度経度のテストを追加
  - 紙タバコのフィルタテストの記述を簡潔化
  - 電子タバコのみフィルタのテストを追加
- `spec/factories/smoking_areas.rb` / `spec/factories/tobacco_types.rb` を追加し、インラインな `create` を `factory` 呼び出しに置き換え
- `spec/models/smoking_area_spec.rb` を作成し以下を記述
  - バリデーション（ `name` / 緯度経度 / 各長さ / `is_indoor` ）
  - `normalize_tobacco_types` の補完分岐と `must_have_tobacco_types`
  - `display_order` 昇順・削除時の連動
 
## 動作確認
- `bundle exec rspec` を実行し examples 数 1 以上・0 failures で完了する

## 影響範囲
- アプリ機能/API：影響なし
- データ移行：不要
- DB変更：なし

## 関連Issue
Closes #110 
Closes #111 