### PR TITLE
Test/113 add tobacco types specs

### DIFF
--- a/spec/models/tobacco_type_spec.rb
+++ b/spec/models/tobacco_type_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.describe TobaccoType, type: :model do
+  describe "validations" do
+    it "is valid with default attributes" do
+      tobacco_type = build(:tobacco_type)
+      expect(tobacco_type).to be_valid
+    end
+
+    it "is invalid without a name" do
+      tobacco_type = build(:tobacco_type, name: nil)
+      expect(tobacco_type).to be_invalid
+      expect(tobacco_type.errors).to be_of_kind(:name, :blank)
+    end
+
+    it "is invalid when the name is longer than 30 characters" do
+      tobacco_type = build(:tobacco_type, name: "a" * 30)
+      expect(tobacco_type).to be_valid
+
+      tobacco_type = build(:tobacco_type, name: "a" * 31)
+      expect(tobacco_type).to be_invalid
+    end
+
+    it "is invalid when the name is already taken" do
+      create(:tobacco_type, name: "duplicate")
+      tobacco_type = build(:tobacco_type, name: "duplicate")
+      expect(tobacco_type).to be_invalid
+    end
+
+    it "is invalid without an icon" do
+      tobacco_type = build(:tobacco_type, icon: nil)
+      expect(tobacco_type).to be_invalid
+    end
+
+    it "is invalid when the icon is longer than 255 characters" do
+      tobacco_type = build(:tobacco_type, icon: "a" * 255)
+      expect(tobacco_type).to be_valid
+
+      tobacco_type = build(:tobacco_type, icon: "a" * 256)
+      expect(tobacco_type).to be_invalid
+    end
+
+    it "is invalid without a display_order" do
+      tobacco_type = build(:tobacco_type, display_order: nil)
+      expect(tobacco_type).to be_invalid
+    end
+
+    it "is invalid when the display_order is already taken" do
+      create(:tobacco_type, display_order: 100)
+      tobacco_type = build(:tobacco_type, display_order: 100)
+      expect(tobacco_type).to be_invalid
+    end
+  end
+end

--- a/spec/requests/v1/tobacco_types_spec.rb
+++ b/spec/requests/v1/tobacco_types_spec.rb
@@ -3,18 +3,16 @@ require 'rails_helper'
 RSpec.describe "V1::TobaccoTypes", type: :request do
   describe "GET /v1/tobacco_types" do
     it "returns tobacco types sorted by display_order with only allowed fields" do
-
-      TobaccoType.create!(name: "電子タバコ", icon: "electronic cigarette", display_order: 2)
-      TobaccoType.create!(name: "紙タバコ",   icon: "cigarette",            display_order: 1)
+      # 並び替えを検証するため、あえて display_order の降順で作成する
+      create(:tobacco_type, :electronic)
+      create(:tobacco_type, :paper)
 
       get "/v1/tobacco_types"
 
       expect(response).to have_http_status(:ok)
-
       json = JSON.parse(response.body)
 
       expect(json.size).to eq 2
-
       expect(json.map { |t| t["name"] }).to eq ["紙タバコ", "電子タバコ"]
       expect(json.map { |t| t["display_order"] }).to eq [1, 2]
 


### PR DESCRIPTION
## 概要
`tobacco_types` の `request spec` を `factory` を使う形に書き換え、未整備の `model spec` を追加する。

## 背景
- `request spec` が `TobaccoType` をインラインで生成しており、`factory_bot` 導入後も `smoking_areas_spec.rb` 側と生成方法が統一されていない。
- モデル `TobaccoType` にはバリデーション（ `name` の必須 / 30文字 / 一意性、`icon` の必須 / 255文字、`display_order` の必須 / 一意性）を検証する model spec が存在しない。
- モデルに宣言されている挙動はテストで固定する方針とし、呼び出し経路が無く将来実装予定のない削除の連動は対象に含めない。

## 内容
- `spec/requests/v1/tobacco_types_spec.rb` のインラインな `create` を `factory` 呼び出しに置き換え
- `spec/models/tobacco_type_spec.rb` を作成し以下のバリデーションテストを追加
  - `name` の必須・長さ・一意性
  - `icon` の必須・長さ
  - `display_order` の必須・一意性

## 動作確認
- `bundle exec rspec` が examples 数 1 以上・0 failures で完了する

## 影響範囲
- アプリ機能/API：影響なし
- データ移行：不要
- DB変更：なし

## 関連Issue
Closes #113 