### PR TITLE
refactor: replace unreferenced let! with before

### DIFF
--- a/spec/models/smoking_area_spec.rb
+++ b/spec/models/smoking_area_spec.rb
@@ -2,8 +2,10 @@ require 'rails_helper'
 
 RSpec.describe SmokingArea, type: :model do
   describe "validations" do
-    let!(:paper) { create(:tobacco_type, :paper) }
-    let!(:electronic) { create(:tobacco_type, :electronic)}
+    before do
+      create(:tobacco_type, :paper)
+      create(:tobacco_type, :electronic)
+    end
 
     it "is valid with default attributes" do
       smoking_area = build(:smoking_area)


### PR DESCRIPTION
## 概要
`spec/models/smoking_area_spec.rb` の `describe "validations"` 内にある `let!(:paper)` / `let!(:electronic)` を `before` に置き換える。

## 背景
- ブロック内で一度も名前を参照していない。副作用（マスタの事前投入）のみが目的であるため。
- 現状の let! は参照しないのに名前を付けていて、読み手に後続での参照を予告する誤ったシグナルになる。なお `normalize_tobacco_types` が `valid?` の中でマスタを引くため、データの投入自体は削除できない。

## 内容
- `describe "validations"` 内の `let!` 2行を `before` ブロックに置き換える

## 動作確認
- `bundle exec rspec spec/models/smoking_area_spec.rb` を実行しテストが全件通過する

## 影響範囲
- アプリ機能/API：影響なし
- データ移行：不要
- DB変更：なし

## 関連Issue
Closes #117 