### PR TITLE
Docs/107 fix readme repository name

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,18 +111,18 @@ zodは型が存在しないRailsから取得したデータが意図している
 
 ### リポジトリのクローン
 ```bash
-git clone https://github.com/Deku-toshi/smoking_area_map_api.git
-cd smoking_area_map_api
+git clone https://github.com/Deku-toshi/Ippuku.git
+cd Ippuku
 ```
 
 ### 環境変数の設定
 
-**バックエンド**（`smoking_area_map_api/.env.local`）
+**バックエンド**（`Ippuku/.env.local`）
 ```bash
 DATABASE_PASSWORD=<任意のパスワードを入れてください>
 ```
 
-**フロントエンド**（`smoking_area_map_api/frontend/.env.local`）
+**フロントエンド**（`Ippuku/frontend/.env.local`）
 ```bash
 VITE_GOOGLE_MAPS_API_KEY=<取得したGoogleMapsAPIキーを入れてください>
 VITE_GOOGLE_MAPS_MAP_ID=<取得したMapIDを入れてください>
@@ -130,7 +130,7 @@ VITE_GOOGLE_MAPS_MAP_ID=<取得したMapIDを入れてください>
 
 ### Rails API（バックエンド）
 ```bash
-cd smoking_area_map_api
+cd Ippuku
 bundle install
 rails db:create db:migrate
 rails db:seed
@@ -139,7 +139,7 @@ rails s
 
 ### フロントエンド
 ```bash
-cd smoking_area_map_api/frontend
+cd Ippuku/frontend
 npm install
 npm run dev
 ```

--- a/README.md
+++ b/README.md
@@ -107,6 +107,19 @@ zodは型が存在しないRailsから取得したデータが意図している
 
 ![ER図](docs/images/er-diagram.png)
 
+## ディレクトリ構成
+
+リポジトリのルートがRails API（APIモード）のルートを兼ねています。
+
+```
+Ippuku/
+├── app/        # Rails: モデル・コントローラ
+├── config/     # Rails: ルーティング・CORS・環境設定
+├── spec/       # Rails: RSpec
+├── Gemfile     # Rails: 依存管理
+└── frontend/   # React + TypeScript（Vite）
+```
+
 ## ローカル環境での立ち上げ方法
 
 ### リポジトリのクローン


### PR DESCRIPTION
## 概要
README「ローカル環境での立ち上げ方法」に旧リポジトリ名 `smoking_area_map_api` が6箇所残っているため現行の `Ippuku` に修正する。あわせて、リポジトリのルートがRails APIのルートを兼ねている構成が読み取れないため、ディレクトリ構成セクションを追加する。

## 背景
リポジトリ名を `smoking_area_map_api` から `Ippuku` にリネームした際、README内の記述が追従できていない。現状のREADMEどおりに実行すると `git clone` で生成されるディレクトリ名が `Ippuku` になるため、以降の `cd` と環境変数ファイルのパスがすべて誤りとなり、手順を再現できない。
また本リポジトリはルート直下にRails（ `app/` , `config/` , `Gemfile` など）とフロントエンド（ `frontend/` ）が同居する構成だが、フロントエンドのみディレクトリ名で明示され、バックエンドはルートに露出しているため非対称で読み取りづらい。READMEでの明示によって解消する。

## 内容
- clone URL・clone後の `cd` を `Ippuku` に修正
- 環境変数ファイルのパス表記を修正
- Rails API / フロントエンド起動手順の `cd` を修正
- ディレクトリ構成セクションを追加

## 動作確認
- `grep -rn "smoking_area_map_api" README.md` の結果が0件であること

## 影響範囲
- アプリ機能/API：なし
- データ移行：なし
- DB変更：なし

## 関連Issue
Closes #107 